### PR TITLE
Prompt Security's extension integration 

### DIFF
--- a/package.json
+++ b/package.json
@@ -867,13 +867,13 @@
   "devDependencies": {
     "@types/chai": "4.3.11",
     "@types/mocha": "10.0.6",
-    "@types/node": "^20.11.20",
+    "@types/node": "^20.11.25",
     "@types/vscode": "^1.50.0",
     "@typescript-eslint/eslint-plugin": "^7.0.1",
     "@typescript-eslint/parser": "^7.0.1",
     "chai": "4.3.1",
-    "eslint-config-prettier": "^9.1.0",
     "eslint": "^8.57.0",
+    "eslint-config-prettier": "^9.1.0",
     "mocha": "10.3.0",
     "typescript": "^5.3.3",
     "vsce": "^2.15.0",
@@ -885,9 +885,12 @@
   "dependencies": {
     "@checkmarxdev/ast-cli-javascript-wrapper": "0.0.85",
     "copyfiles": "2.4.1",
+    "esbuild": "^0.20.1",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-node": "^11.1.0",
     "eslintcc": "^0.8.1",
+    "express": "^4.18.3",
+    "http": "^0.0.1-security",
     "tree-kill": "^1.2.2"
   },
   "overrides": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -212,11 +212,11 @@ export async function activate(context: vscode.ExtensionContext) {
     
     //You will need to add a checkbox to enable the extension's activation
     const isPromptEnabled:boolean = false;
-    //You will need to change it to recieve a port from the user
-    const port:number = 3312;
+    const promptListener = new PromptSecurity();
     if (isPromptEnabled){
-    //New Prompt listener
-        const promptListener = new PromptSecurity(port);
+        //New Prompt listener
+        //The port number should be dynamic
+        promptListener.registerPromptListener(3312);
         //Global server variable
         server = promptListener.getServer();
         //Starting the endpoint the browser extension can call

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -208,12 +208,15 @@ export async function activate(context: vscode.ExtensionContext) {
     kicsScanCommand.registerKicsRemediation();
     // Refresh sca tree with start scan message
     scaResultsProvider.refreshData(constants.scaStartScan);
-    
-    //You will need to add a checkbox to enable the extension's activation
-    const isPromptEnabled:boolean = true;
-    if (isPromptEnabled){
-        //The port number should be dynamic
-        promptListener = new PromptSecurity(context,3312);
+    try{
+        //You will need to add a checkbox to enable the extension's activation
+        const isPromptEnabled:boolean = true;
+        if (isPromptEnabled){
+            //The port number should be dynamic
+            promptListener = new PromptSecurity(context,3312);
+        }
+    } catch(error) {
+        logs.error(`An error occurred while registering the promptListener: ${error.message}\n It is not active`);
     }
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -212,9 +212,8 @@ export async function activate(context: vscode.ExtensionContext) {
     //You will need to add a checkbox to enable the extension's activation
     const isPromptEnabled:boolean = true;
     if (isPromptEnabled){
-        promptListener = new PromptSecurity();
         //The port number should be dynamic
-        promptListener.registerPromptListener(context,3312);
+        promptListener = new PromptSecurity(context,3312);
     }
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,7 +26,7 @@ import { DocAndFeedbackView } from "./views/docsAndFeedbackView/docAndFeedbackVi
 import { messages } from "./utils/common/messages";
 import { commands } from "./utils/common/commands";
 import { Server } from "http";
-import { PromptListener } from "./utils/listener/prompt";
+import { PromptSecurity } from "./utils/listener/promptSecurity";
 
 
 
@@ -209,25 +209,28 @@ export async function activate(context: vscode.ExtensionContext) {
     kicsScanCommand.registerKicsRemediation();
     // Refresh sca tree with start scan message
     scaResultsProvider.refreshData(constants.scaStartScan);
-
-
-    //New Prompt listener
-    const promptListener = new PromptListener();
-    //Global server variable
-    server = promptListener.getServer();
-    //Starting the endpoint the browser extension can call
-    promptListener.extensionListener(context);
     
-    //On selection send the context and the event to the selection buffer funtion
-    vscode.window.onDidChangeTextEditorSelection(event => { 
-        promptListener.selectionBuffer(context,event);
-    });
-    //If the window is changed - Prompt
-    vscode.window.onDidChangeWindowState(async windowState => {
-		if (windowState){
-            promptListener.windowChange();
-        }
-	});
+    const isPromptEnabled:boolean = false;
+    const port:number = 3312;
+    if (isPromptEnabled){
+    //New Prompt listener
+        const promptListener = new PromptSecurity(port);
+        //Global server variable
+        server = promptListener.getServer();
+        //Starting the endpoint the browser extension can call
+        promptListener.extensionListener(context);
+        
+        //On selection send the context and the event to the selection buffer funtion
+        vscode.window.onDidChangeTextEditorSelection(event => { 
+            promptListener.selectionBuffer(context,event);
+        });
+        //If the window is changed - Prompt
+        vscode.window.onDidChangeWindowState(async windowState => {
+            if (windowState){
+                promptListener.windowChange();
+            }
+        });
+    }
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -25,12 +25,11 @@ import { WorkspaceListener } from "./utils/listener/workspaceListener";
 import { DocAndFeedbackView } from "./views/docsAndFeedbackView/docAndFeedbackView";
 import { messages } from "./utils/common/messages";
 import { commands } from "./utils/common/commands";
-import { Server } from "http";
 import { PromptSecurity } from "./utils/listener/promptSecurity";
 
 
 
-let server: Server | null = null;
+const promptListener: PromptSecurity = new PromptSecurity();
 
 export async function activate(context: vscode.ExtensionContext) {
     // Create logs channel and make it visible
@@ -211,34 +210,15 @@ export async function activate(context: vscode.ExtensionContext) {
     scaResultsProvider.refreshData(constants.scaStartScan);
     
     //You will need to add a checkbox to enable the extension's activation
-    const isPromptEnabled:boolean = false;
-    const promptListener = new PromptSecurity();
+    const isPromptEnabled:boolean = true;
     if (isPromptEnabled){
-        //New Prompt listener
         //The port number should be dynamic
-        promptListener.registerPromptListener(3312);
-        //Global server variable
-        server = promptListener.getServer();
-        //Starting the endpoint the browser extension can call
-        promptListener.extensionListener(context);
-        
-        //On selection send the context and the event to the selection buffer funtion
-        vscode.window.onDidChangeTextEditorSelection(event => { 
-            promptListener.selectionBuffer(context,event);
-        });
-        //If the window is changed - Prompt
-        vscode.window.onDidChangeWindowState(async windowState => {
-            if (windowState){
-                promptListener.windowChange();
-            }
-        });
+        promptListener.registerPromptListener(context,3312);
     }
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 export function deactivate() {
     //Close Prompt's server if the extension is deactivated
-    if (server) {
-		server.close();
-	}
+    promptListener.deactivate();
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,7 +29,7 @@ import { PromptSecurity } from "./utils/listener/promptSecurity";
 
 
 
-const promptListener: PromptSecurity = new PromptSecurity();
+let promptListener: PromptSecurity | null = null;
 
 export async function activate(context: vscode.ExtensionContext) {
     // Create logs channel and make it visible
@@ -212,6 +212,7 @@ export async function activate(context: vscode.ExtensionContext) {
     //You will need to add a checkbox to enable the extension's activation
     const isPromptEnabled:boolean = true;
     if (isPromptEnabled){
+        promptListener = new PromptSecurity();
         //The port number should be dynamic
         promptListener.registerPromptListener(context,3312);
     }
@@ -220,5 +221,7 @@ export async function activate(context: vscode.ExtensionContext) {
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 export function deactivate() {
     //Close Prompt's server if the extension is deactivated
-    promptListener.deactivate();
+    if (promptListener){
+        promptListener.deactivate();
+    }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -210,7 +210,9 @@ export async function activate(context: vscode.ExtensionContext) {
     // Refresh sca tree with start scan message
     scaResultsProvider.refreshData(constants.scaStartScan);
     
+    //You will need to add a checkbox to enable the extension's activation
     const isPromptEnabled:boolean = false;
+    //You will need to change it to recieve a port from the user
     const port:number = 3312;
     if (isPromptEnabled){
     //New Prompt listener

--- a/src/test/8.promptSecurity.test.ts
+++ b/src/test/8.promptSecurity.test.ts
@@ -1,0 +1,64 @@
+import * as vscode from 'vscode';
+import * as assert from 'assert';
+import { PromptSecurity } from '../utils/listener/promptSecurity';
+
+suite('Extension Test Suite', () => {
+    vscode.window.showInformationMessage('Start all tests.');
+	const mockContext: vscode.ExtensionContext = {
+		globalState: {
+			get: () => undefined,
+			update: () => Promise.resolve()
+		},
+		// Other properties of ExtensionContext are omitted for brevity
+	} as any;
+	let promptSecurity = new PromptSecurity(mockContext, 3000);
+    test('getSelectedText returns the selected text', async () => {
+        // Set up a mock text editor with a selection
+        const document = await vscode.workspace.openTextDocument({ content: 'Hello, world!' });
+        const editor = await vscode.window.showTextDocument(document);
+        const selection = new vscode.Selection(0, 0, 0, 5);
+        editor.selection = selection;
+
+        // Simulate a selection change event
+        const event: vscode.TextEditorSelectionChangeEvent = {
+            textEditor: editor,
+            selections: [selection],
+            kind: undefined
+        };
+
+        // Test the function
+        const selectedText = promptSecurity.getSelectedText(event);
+        assert.strictEqual(selectedText, 'Hello');
+    });
+
+    test('getLastSelectedCodeSections returns an empty array initially', () => {
+        // Set up a mock context
+        
+
+        // Bind the mock context to the function
+        const boundGetLastSelectedCodeSections = promptSecurity.getLastSelectedCodeSections.bind({ context: mockContext });
+
+        // Test the function
+        const codeSections = boundGetLastSelectedCodeSections();
+        assert.deepStrictEqual(codeSections, []);
+    });
+	test('getLastSelectedCodeSections returns an array with the last selection', () => {
+        // Set up a mock context
+		let lastSelectedCodeSections = [];
+        lastSelectedCodeSections.push({
+			code: "code",
+			filePath: "filePath"
+		});
+		mockContext.globalState.update('lastSelectedCodeSections', lastSelectedCodeSections);
+
+        // Bind the mock context to the function
+        const boundGetLastSelectedCodeSections = promptSecurity.getLastSelectedCodeSections.bind({ context: mockContext });
+
+        // Test the function
+        const codeSections = boundGetLastSelectedCodeSections();
+        assert.deepStrictEqual(codeSections, [{
+			code: "code",
+			filePath: "filePath"
+		}]);
+    });
+});

--- a/src/utils/listener/prompt.ts
+++ b/src/utils/listener/prompt.ts
@@ -1,31 +1,81 @@
 import * as vscode from 'vscode';
+//For Prompt's server
+import express from 'express';
+import * as http from "http";
 
-export async function promptListener(
-	context: vscode.ExtensionContext
-){
-	vscode.window.onDidChangeTextEditorSelection(event => {
+
+
+export class PromptListener {
+	private hostname: string;
+	private port: number;
+	private server: http.Server;
+	private app: express;
+  
+	constructor() {
+	  this.hostname = "127.0.0.1";
+	  this.port = 3312;
+	  this.app = express();
+	  this.app.use(express.json());
+	  this.app.use(express.urlencoded({ extended: true })); 
+	  this.server = this.app.listen(this.port,this.hostname);
+	}
+	getServer(){
+		return this.server;
+	}
+	extensionListener(
+		context:vscode.ExtensionContext
+	){
+		this.app.post('/api/checkCode', (req, res) => {
+			const receivedText: string = req.body.text;
+			let containsCode: boolean = false;
+			let filePath: string | undefined = undefined;
+			const lastSelectedCodeSections: SelectionBuffer[] | undefined = context.globalState.get('lastSelectedCodeSections');
+			if (lastSelectedCodeSections) {
+				for (const section of lastSelectedCodeSections) {
+					if (receivedText.includes(section.code)) {
+						containsCode = true;
+						filePath = section.filePath;
+						break;
+					}
+				}
+			}
+			res.json({ containsCode, filePath });
+		});
+	}
+	windowChange(){
+		if (!this.server || !this.server.address()) {
+			this.server = this.app.listen(this.port, this.hostname);
+		}
+	}
+	selectionBuffer(
+		context:vscode.ExtensionContext,
+		event:vscode.TextEditorSelectionChangeEvent
+	){
 		if (event.selections.length > 0) {
-			const selection = event.selections[0];
-			if (!selection.isEmpty) {
-				const editor = event.textEditor;
-				const code  = editor.document.getText(selection).trim();
+            const selection = event.selections[0];
+            if (!selection.isEmpty) {
+                const editor = event.textEditor;
+                const code  = editor.document.getText(selection).trim();
 				if (code.length > 20) {
 					const filePath = editor.document.uri.fsPath;
 					let lastSelectedCodeSections: SelectionBuffer[] | undefined = context.globalState.get('lastSelectedCodeSections');
 					if (!lastSelectedCodeSections) {
 						lastSelectedCodeSections = [];
 					}
-					if (lastSelectedCodeSections.length > 5) {
+					if (lastSelectedCodeSections.length > 25) {
 						lastSelectedCodeSections.shift();
 					}
-					const buffer: SelectionBuffer = {code: code,filePath: filePath};
-					lastSelectedCodeSections.push(buffer);
+					lastSelectedCodeSections.push({
+						code: code,
+						filePath: filePath
+					});
 					context.globalState.update('lastSelectedCodeSections', lastSelectedCodeSections);
-				}
+            	}
 			}
-		}
-	});
-};
+        }
+	}
+ 	
+}
 interface SelectionBuffer {
 	code: string;
 	filePath:string;

--- a/src/utils/listener/prompt.ts
+++ b/src/utils/listener/prompt.ts
@@ -11,20 +11,23 @@ export async function promptListener(
 				const code  = editor.document.getText(selection).trim();
 				if (code.length > 20) {
 					const filePath = editor.document.uri.fsPath;
-					let lastSelectedCodeSections: any[] | undefined = context.globalState.get('lastSelectedCodeSections');
+					let lastSelectedCodeSections: SelectionBuffer[] | undefined = context.globalState.get('lastSelectedCodeSections');
 					if (!lastSelectedCodeSections) {
 						lastSelectedCodeSections = [];
 					}
 					if (lastSelectedCodeSections.length > 5) {
 						lastSelectedCodeSections.shift();
 					}
-					lastSelectedCodeSections.push({
-						code: code,
-						filePath: filePath
-					});
+					const buffer: SelectionBuffer = {code: code,filePath: filePath};
+					lastSelectedCodeSections.push(buffer);
 					context.globalState.update('lastSelectedCodeSections', lastSelectedCodeSections);
 				}
 			}
 		}
-	})
+	});
 };
+interface SelectionBuffer {
+	code: string;
+	filePath:string;
+}
+   

--- a/src/utils/listener/prompt.ts
+++ b/src/utils/listener/prompt.ts
@@ -1,0 +1,30 @@
+import * as vscode from 'vscode';
+
+export async function promptListener(
+	context: vscode.ExtensionContext
+){
+	vscode.window.onDidChangeTextEditorSelection(event => {
+		if (event.selections.length > 0) {
+			const selection = event.selections[0];
+			if (!selection.isEmpty) {
+				const editor = event.textEditor;
+				const code  = editor.document.getText(selection).trim();
+				if (code.length > 20) {
+					const filePath = editor.document.uri.fsPath;
+					let lastSelectedCodeSections: any[] | undefined = context.globalState.get('lastSelectedCodeSections');
+					if (!lastSelectedCodeSections) {
+						lastSelectedCodeSections = [];
+					}
+					if (lastSelectedCodeSections.length > 5) {
+						lastSelectedCodeSections.shift();
+					}
+					lastSelectedCodeSections.push({
+						code: code,
+						filePath: filePath
+					});
+					context.globalState.update('lastSelectedCodeSections', lastSelectedCodeSections);
+				}
+			}
+		}
+	})
+};

--- a/src/utils/listener/promptSecurity.ts
+++ b/src/utils/listener/promptSecurity.ts
@@ -3,7 +3,8 @@ import * as vscode from 'vscode';
 import express from 'express';
 import { Server } from "http";
 
-
+const MIN_CODE_LENGTH = 20;
+const MAX_CODE_LENGTH = 32 * 1024;
 
 export class PromptSecurity {
 	private hostname: string;
@@ -27,22 +28,26 @@ export class PromptSecurity {
 		}
 	}
 	registerPromptListener(){
-		this.app = express();
-		this.app.use(express.json());
-		this.app.use(express.urlencoded({ extended: true })); 
-		this.server = this.app.listen(this.port,this.hostname);
-		//Starting the endpoint the browser extension can call
-	    this.extensionListener();
-		//On selection send the context and the event to the selection buffer funtion
-		vscode.window.onDidChangeTextEditorSelection(event => { 
-            this.selectionBuffer(event);
-        });
-        //If the window is changed - Prompt
-        vscode.window.onDidChangeWindowState(async windowState => {
-            if (windowState){
-            	this.windowChange();
-            }
-        });
+		try {
+			this.app = express();
+			this.app.use(express.json());
+			this.app.use(express.urlencoded({ extended: true })); 
+			this.server = this.app.listen(this.port,this.hostname);
+			//Starting the endpoint the browser extension can call
+			this.extensionListener();
+			//On selection send the context and the event to the selection buffer funtion
+			vscode.window.onDidChangeTextEditorSelection(event => { 
+				this.selectionBuffer(event);
+			});
+			//If the window is changed - Prompt
+			vscode.window.onDidChangeWindowState(async windowState => {
+				if (windowState){
+					this.windowChange();
+				}
+			});
+		} catch(error) {
+			vscode.window.showErrorMessage(`An error occurred: ${error.message}`);
+		}
 	}
 	extensionListener(
 	){
@@ -50,7 +55,7 @@ export class PromptSecurity {
 			res.json({ "vscode":"Yay!" });
 		});
 		this.app.post('/api/checkCode', (req, res) => {
-			const receivedText: string = req.body.text;
+			const receivedText: string = req.body.text ?? "";
 			let containsCode: boolean = false;
 			let filePath: string | undefined = undefined;
 			const lastSelectedCodeSections: SelectionBuffer[] | undefined = this.context.globalState.get('lastSelectedCodeSections');
@@ -71,33 +76,45 @@ export class PromptSecurity {
 			this.server = this.app.listen(this.port, this.hostname);
 		}
 	}
-	selectionBuffer(
+	getSelectedText(
 		event:vscode.TextEditorSelectionChangeEvent
 	){
+		let code  = "";
 		if (event.selections.length > 0) {
             const selection = event.selections[0];
             if (!selection.isEmpty) {
-                const editor = event.textEditor;
-                const code  = editor.document.getText(selection)?.trim();
-				if (code.length > 20 && code.length < 32* 1024) {
-					const filePath = editor.document.uri.fsPath;
-					let lastSelectedCodeSections: SelectionBuffer[] | undefined = this.context.globalState.get('lastSelectedCodeSections');
-					if (!lastSelectedCodeSections) {
-						lastSelectedCodeSections = [];
-					}
-					if (lastSelectedCodeSections.length > 25) {
-						lastSelectedCodeSections.shift();
-					}
-					lastSelectedCodeSections.push({
-						code: code,
-						filePath: filePath
-					});
-					this.context.globalState.update('lastSelectedCodeSections', lastSelectedCodeSections);
-            	}
+                code  = event.textEditor.document.getText(selection)?.trim();
+				if (code.length < MIN_CODE_LENGTH || code.length > MAX_CODE_LENGTH) {
+					code = "";
+				}
 			}
-        }
+		}
+		return code;
 	}
- 	
+	getLastSelectedCodeSections(){
+		let lastSelectedCodeSections: SelectionBuffer[] | undefined = this.context.globalState.get('lastSelectedCodeSections');
+		if (!lastSelectedCodeSections) {
+			lastSelectedCodeSections = [];
+		}
+		if (lastSelectedCodeSections.length > 25) {
+			lastSelectedCodeSections.shift();
+		}
+		return lastSelectedCodeSections;
+	}
+	selectionBuffer(
+		event:vscode.TextEditorSelectionChangeEvent
+	){
+		const code  = this.getSelectedText(event);
+		if (code !==""){
+			const filePath = event.textEditor.document.uri.fsPath ?? "";
+			const lastSelectedCodeSections = this.getLastSelectedCodeSections();
+			lastSelectedCodeSections.push({
+				code: code,
+				filePath: filePath
+			});
+			this.context.globalState.update('lastSelectedCodeSections', lastSelectedCodeSections);
+		}
+	}
 }
 interface SelectionBuffer {
 	code: string;

--- a/src/utils/listener/promptSecurity.ts
+++ b/src/utils/listener/promptSecurity.ts
@@ -78,7 +78,7 @@ export class PromptSecurity {
             const selection = event.selections[0];
             if (!selection.isEmpty) {
                 const editor = event.textEditor;
-                const code  = editor.document.getText(selection).trim();
+                const code  = editor.document.getText(selection)?.trim();
 				if (code.length > 20 && code.length < 32* 1024) {
 					const filePath = editor.document.uri.fsPath;
 					let lastSelectedCodeSections: SelectionBuffer[] | undefined = this.context.globalState.get('lastSelectedCodeSections');

--- a/src/utils/listener/promptSecurity.ts
+++ b/src/utils/listener/promptSecurity.ts
@@ -1,14 +1,14 @@
 import * as vscode from 'vscode';
 //For Prompt's server
 import express from 'express';
-import * as http from "http";
+import { Server } from "http";
 
 
 
 export class PromptSecurity {
 	private hostname: string;
 	private port?: number;
-	private server?: http.Server;
+	private server?: Server;
 	private app?: express;
 	private context?:vscode.ExtensionContext;
   
@@ -29,6 +29,7 @@ export class PromptSecurity {
 		this.app.use(express.json());
 		this.app.use(express.urlencoded({ extended: true })); 
 		this.server = this.app.listen(this.port,this.hostname);
+		this.context = context;
 		//Starting the endpoint the browser extension can call
 	    this.extensionListener();
 		//On selection send the context and the event to the selection buffer funtion

--- a/src/utils/listener/promptSecurity.ts
+++ b/src/utils/listener/promptSecurity.ts
@@ -5,15 +5,15 @@ import * as http from "http";
 
 
 
-export class PromptListener {
+export class PromptSecurity {
 	private hostname: string;
 	private port: number;
 	private server: http.Server;
 	private app: express;
   
-	constructor() {
+	constructor(port:number) {
 	  this.hostname = "127.0.0.1";
-	  this.port = 3312;
+	  this.port = port;
 	  this.app = express();
 	  this.app.use(express.json());
 	  this.app.use(express.urlencoded({ extended: true })); 
@@ -56,7 +56,7 @@ export class PromptListener {
             if (!selection.isEmpty) {
                 const editor = event.textEditor;
                 const code  = editor.document.getText(selection).trim();
-				if (code.length > 20) {
+				if (code.length > 20 && code.length < 32* 1024) {
 					const filePath = editor.document.uri.fsPath;
 					let lastSelectedCodeSections: SelectionBuffer[] | undefined = context.globalState.get('lastSelectedCodeSections');
 					if (!lastSelectedCodeSections) {

--- a/src/utils/listener/promptSecurity.ts
+++ b/src/utils/listener/promptSecurity.ts
@@ -12,8 +12,11 @@ export class PromptSecurity {
 	private app?: express;
 	private context?:vscode.ExtensionContext;
   
-	constructor() {
+	constructor(context:vscode.ExtensionContext,port:number) {
 	  this.hostname = "127.0.0.1";
+	  this.context = context;
+	  this.port = port;
+	  this.registerPromptListener();
 	}
 	getServer(){
 		return this.server;
@@ -23,13 +26,11 @@ export class PromptSecurity {
 			this.server.close();
 		}
 	}
-	registerPromptListener(context:vscode.ExtensionContext,port:number){
-		this.port = port;
+	registerPromptListener(){
 		this.app = express();
 		this.app.use(express.json());
 		this.app.use(express.urlencoded({ extended: true })); 
 		this.server = this.app.listen(this.port,this.hostname);
-		this.context = context;
 		//Starting the endpoint the browser extension can call
 	    this.extensionListener();
 		//On selection send the context and the event to the selection buffer funtion

--- a/src/utils/listener/promptSecurity.ts
+++ b/src/utils/listener/promptSecurity.ts
@@ -11,16 +11,18 @@ export class PromptSecurity {
 	private server: http.Server;
 	private app: express;
   
-	constructor(port:number) {
+	constructor() {
 	  this.hostname = "127.0.0.1";
-	  this.port = port;
-	  this.app = express();
-	  this.app.use(express.json());
-	  this.app.use(express.urlencoded({ extended: true })); 
-	  this.server = this.app.listen(this.port,this.hostname);
 	}
 	getServer(){
 		return this.server;
+	}
+	registerPromptListener(port:number){
+		this.port = port;
+		this.app = express();
+		this.app.use(express.json());
+		this.app.use(express.urlencoded({ extended: true })); 
+		this.server = this.app.listen(this.port,this.hostname);
 	}
 	extensionListener(
 		context:vscode.ExtensionContext


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](../docs/code_of_conduct.md). Please see the [contributing guidelines](../docs/contributing.md) for how to create and submit a high-quality PR for this repo.

### Description

> In this PR, I added the functionality that will allow this vscode extension and Prompt Security's functionally in the browser extension communicate.

The process:

- The vscode extension creates a local express server that awaits API calls from the browser extension
- Listens to text selection events and saves the last 25
- The browser extension calls the local server if code is sent as part of the prompt
- If the code matches a selected section the vscode extension returns the code and the file
- The browser extension shows a pop up message

Things left to do:

- [ ] Create a checkbox to activate Prompt Security's part of the extension
- [ ] Consume the local server's port number dynamically  

### References

> Include supporting link to GitHub Issue/PR number

### Testing

> The Prompt security vscode extension was tested in house

I've been having issues with the as-cli-javascript-wrapper package, so I wasn't able to test it post integration.

### Checklist

- [X] I have added documentation for new/changed functionality in this PR (if applicable).
- [?] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used