### PR TITLE
AST-37667 send the agent to results cmd

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "ast-results",
       "version": "2.11.0",
       "dependencies": {
-        "@checkmarxdev/ast-cli-javascript-wrapper": "0.0.88",
+        "@checkmarxdev/ast-cli-javascript-wrapper": "0.0.89",
         "copyfiles": "2.4.1",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-node": "^11.1.0",
@@ -47,9 +47,10 @@
     },
     "node_modules/@checkmarxdev/ast-cli-javascript-wrapper": {
       "name": "@CheckmarxDev/ast-cli-javascript-wrapper",
-      "version": "0.0.88",
-      "resolved": "https://npm.pkg.github.com/download/@CheckmarxDev/ast-cli-javascript-wrapper/0.0.88/4307cc481b34fc77505433081a5d900e975ae91f",
-      "integrity": "sha512-3nhP4FEgIlxH3645wYPVQ+ZasI4JXXnLn3jk6EKbU4OF1hX+UwOSrjVSLACIFDvH7u0Maf4q51Aac56yzBHg5A==",
+      "version": "0.0.89",
+      "resolved": "https://npm.pkg.github.com/download/@CheckmarxDev/ast-cli-javascript-wrapper/0.0.89/7733630400c40067d545157943c61adbb0a76ac2",
+      "integrity": "sha512-kn+/uICyf9jlnvlcyrLOuEVRGk7RS8UCBJFrdXtvw7sfPU9NmtBtM6gba4gpZxXjqxbhL+oG4F497oIr3XxMQA==",
+      "license": "ISC",
       "dependencies": {
         "log4js": "^6.9.1"
       }
@@ -5758,9 +5759,9 @@
       "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA=="
     },
     "@checkmarxdev/ast-cli-javascript-wrapper": {
-      "version": "npm:@CheckmarxDev/ast-cli-javascript-wrapper@0.0.88",
-      "resolved": "https://npm.pkg.github.com/download/@CheckmarxDev/ast-cli-javascript-wrapper/0.0.88/4307cc481b34fc77505433081a5d900e975ae91f",
-      "integrity": "sha512-3nhP4FEgIlxH3645wYPVQ+ZasI4JXXnLn3jk6EKbU4OF1hX+UwOSrjVSLACIFDvH7u0Maf4q51Aac56yzBHg5A==",
+      "version": "npm:@CheckmarxDev/ast-cli-javascript-wrapper@0.0.89",
+      "resolved": "https://npm.pkg.github.com/download/@CheckmarxDev/ast-cli-javascript-wrapper/0.0.89/7733630400c40067d545157943c61adbb0a76ac2",
+      "integrity": "sha512-kn+/uICyf9jlnvlcyrLOuEVRGk7RS8UCBJFrdXtvw7sfPU9NmtBtM6gba4gpZxXjqxbhL+oG4F497oIr3XxMQA==",
       "requires": {
         "log4js": "^6.9.1"
       }

--- a/package.json
+++ b/package.json
@@ -883,7 +883,7 @@
     "webpack-cli": "^5.1.4"
   },
   "dependencies": {
-    "@checkmarxdev/ast-cli-javascript-wrapper": "0.0.88",
+    "@checkmarxdev/ast-cli-javascript-wrapper": "0.0.89",
     "copyfiles": "2.4.1",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-node": "^11.1.0",

--- a/src/cx/cx.ts
+++ b/src/cx/cx.ts
@@ -113,7 +113,7 @@ export class Cx implements CxPlatform {
 		params.set(CxParamType.S, sourcePath);
 		params.set(CxParamType.BRANCH, branchName);
 		params.set(CxParamType.PROJECT_NAME, projectName);
-		params.set(CxParamType.AGENT, "VS Code");
+		params.set(CxParamType.AGENT, constants.vsCodeAgent);
 		params.set(CxParamType.ADDITIONAL_PARAMETERS, constants.scanCreateAdditionalParameters);
 		const scan = await cx.scanCreate(params);
 		return scan.payload[0];
@@ -141,7 +141,7 @@ export class Cx implements CxPlatform {
 			return;
 		}
 		const cx = new CxWrapper(config);
-		await cx.getResults(scanId, constants.resultsFileExtension, constants.resultsFileName, getFilePath());
+		await cx.getResults(scanId, constants.resultsFileExtension, constants.resultsFileName, getFilePath(), constants.vsCodeAgent);
 	}
 
 	async getScan(scanId: string | undefined): Promise<CxScan | undefined> {

--- a/src/utils/common/constants.ts
+++ b/src/utils/common/constants.ts
@@ -124,7 +124,7 @@ export const constants = {
   cxKicsAutoScan: "Activate KICS Auto Scanning",
 
   projectLimit: "limit=10000",
-  scanAgent: "VS Code",
+  vsCodeAgent: "VS Code",
   cxOne: "checkmarxOne",
   additionalParams: "additionalParams",
   apiKey: "apiKey",


### PR DESCRIPTION
### Description

> Send the agent flag to the results command
> This flag is used to filter the container results until the plugin supports this engine type.

### References

> https://checkmarx.atlassian.net/browse/AST-37667

### Testing

> Describe how this change was tested. Be specific about anything not tested and reasons why. If this solution has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR (if applicable).
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used