### PR TITLE
VSCode | Fix create scan with project name that contains ':' (AST-55377)

### DIFF
--- a/src/views/resultsView/createScanProvider.ts
+++ b/src/views/resultsView/createScanProvider.ts
@@ -53,7 +53,7 @@ async function createScanForProject(
 ) {
   const scanBranch: Item = context.workspaceState.get(constants.branchIdKey);
   const projectForScan: Item = context.workspaceState.get(constants.projectIdKey);
-  const projectName = projectForScan.name.match(/Project:\s*(.+)/)[1].trim();
+  const projectName = projectForScan.name.match(new RegExp(`${constants.projectLabel}\\s*(.+)`))[1].trim();
   const workspaceFolder = vscode.workspace.workspaceFolders[0];
   logs.info(messages.scanStartWorkspace + workspaceFolder.uri.fsPath);
   const scanCreateResponse = await cx.scanCreate(

--- a/src/views/resultsView/createScanProvider.ts
+++ b/src/views/resultsView/createScanProvider.ts
@@ -53,7 +53,7 @@ async function createScanForProject(
 ) {
   const scanBranch: Item = context.workspaceState.get(constants.branchIdKey);
   const projectForScan: Item = context.workspaceState.get(constants.projectIdKey);
-  const projectName = projectForScan.name.split(":")[1].trim();
+  const projectName = projectForScan.name.match(/Project:\s*(.+)/)[1].trim();
   const workspaceFolder = vscode.workspace.workspaceFolders[0];
   logs.info(messages.scanStartWorkspace + workspaceFolder.uri.fsPath);
   const scanCreateResponse = await cx.scanCreate(


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](../docs/code_of_conduct.md). Please see the [contributing guidelines](../docs/contributing.md) for how to create and submit a high-quality PR for this repo.

### Description

> Fix create scan of project with ':' in name

### References

> https://checkmarx.atlassian.net/browse/AST-55377

### Testing

> Cannot automate this yet

### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used