### PR TITLE
Itay feature: Show SCS results include group by and Filter and Vulnerability Tab (AST-63908)

### DIFF
--- a/src/cx/cxMock.ts
+++ b/src/cx/cxMock.ts
@@ -11,681 +11,1169 @@ import CxVorpal from "@checkmarxdev/ast-cli-javascript-wrapper/dist/main/vorpal/
 import { EMPTY_RESULTS_SCAN_ID } from "../test/utils/envs";
 
 export class CxMock implements CxPlatform {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async scaScanCreate(): Promise<CxScaRealtime[] | any> {
+    return [
+      {
+        type: "Regular",
+        scaType: "vulnerability",
+        label: "sca",
+        severity: "HIGH",
+        description:
+          "decode-uri-component is vulnerable to Improper Input Validation resulting in DoS.",
+        data: {
+          nodes: [
+            {
+              line: 0,
+              column: 0,
+              fileName: "package.json",
+            },
+          ],
+          packageData: [
+            {
+              type: "Advisory",
+              url: "https://github.com/advisories/GHSA-w573-4hg7-7wgq",
+            },
+            {
+              type: "Issue",
+              url: "https://github.com/SamVerschueren/decode-uri-component/issues/5",
+            },
+            {
+              type: "Vulnerable code",
+              url: "https://github.com/SamVerschueren/decode-uri-component/blob/v0.2.0/index.js#L29",
+            },
+          ],
+          packageIdentifier: "decode-uri-component",
+          scaPackageData: {
+            fixLink: "https://devhub.checkmarx.com/cve-details/CVE-2022-38900",
+            supportsQuickFix: false,
+            isDirectDependency: false,
+            typeOfDependency: "",
+          },
+        },
+        comments: {},
+        vulnerabilityDetails: {
+          cweId: "CVE-2022-38900",
+          cvssScore: 7.5,
+          cveName: "CVE-2022-38900",
+          cvss: {
+            version: 2,
+            attackVector: "NETWORK",
+            availability: "HIGH",
+            confidentiality: "NONE",
+            attackComplexity: "LOW",
+            integrityImpact: "NONE",
+            scope: "UNCHANGED",
+            privilegesRequired: "NONE",
+            userInteraction: "NONE",
+          },
+        },
+      },
+    ];
+  }
 
+  async scanCreate() {
+    return {
+      tags: {},
+      groups: undefined,
+      id: "1",
+      projectID: "2588deba-1751-4afc-b7e3-db71727a1edd",
+      status: "Completed",
+      createdAt: "2023-04-19T10:07:37.628413+01:00",
+      updatedAt: "2023-04-19T09:08:27.151913Z",
+      origin: "grpc-java-netty 1.35.0",
+      initiator: "tiago",
+      branch: "main",
+    };
+  }
 
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	async scaScanCreate(): Promise<CxScaRealtime[] | any> {
-		return [
-			{
-				type: "Regular",
-				scaType: "vulnerability",
-				label: "sca",
-				severity: "HIGH",
-				description: "decode-uri-component is vulnerable to Improper Input Validation resulting in DoS.",
-				data: {
-					nodes: [
-						{
-							line: 0,
-							column: 0,
-							fileName: "package.json",
-						},
-					],
-					packageData: [
-						{
-							type: "Advisory",
-							url: "https://github.com/advisories/GHSA-w573-4hg7-7wgq",
-						},
-						{
-							type: "Issue",
-							url: "https://github.com/SamVerschueren/decode-uri-component/issues/5",
-						},
-						{
-							type: "Vulnerable code",
-							url: "https://github.com/SamVerschueren/decode-uri-component/blob/v0.2.0/index.js#L29",
-						},
-					],
-					packageIdentifier: "decode-uri-component",
-					scaPackageData: {
-						fixLink: "https://devhub.checkmarx.com/cve-details/CVE-2022-38900",
-						supportsQuickFix: false,
-						isDirectDependency: false,
-						typeOfDependency: "",
-					},
-				},
-				comments: {
-				},
-				vulnerabilityDetails: {
-					cweId: "CVE-2022-38900",
-					cvssScore: 7.5,
-					cveName: "CVE-2022-38900",
-					cvss: {
-						version: 2,
-						attackVector: "NETWORK",
-						availability: "HIGH",
-						confidentiality: "NONE",
-						attackComplexity: "LOW",
-						integrityImpact: "NONE",
-						scope: "UNCHANGED",
-						privilegesRequired: "NONE",
-						userInteraction: "NONE",
-					},
-				},
-			}
-		];
-	}
+  async scanCancel() {
+    return true;
+  }
 
-	async scanCreate() {
-		return {
-			tags: {
-			},
-			groups: undefined,
-			id: "1",
-			projectID: "2588deba-1751-4afc-b7e3-db71727a1edd",
-			status: "Completed",
-			createdAt: "2023-04-19T10:07:37.628413+01:00",
-			updatedAt: "2023-04-19T09:08:27.151913Z",
-			origin: "grpc-java-netty 1.35.0",
-			initiator: "tiago",
-			branch: "main",
-		};
-	}
+  async getResults(scanId: string) {
+    let results;
 
-	async scanCancel() {
-		return true;
-	}
+    if (scanId === "2" || scanId === EMPTY_RESULTS_SCAN_ID) {
+      results = {
+        results: [],
+      };
+    } else {
+      results = {
+        results: [
+          {
+            type: "kics",
+            label: "IaC Security",
+            id: "150256",
+            similarityId:
+              "92742543fa8505b3ba24ff54894c94594d0d9e3873b05fb38dbcbdef40aa3062",
+            status: "NEW",
+            state: "TO_VERIFY",
+            severity: "LOW",
+            created: "2022-09-02T10:45:29Z",
+            firstFoundAt: "2022-08-26T10:28:36Z",
+            foundAt: "2022-09-02T10:45:29Z",
+            firstScanId: "cb834dcd-aaec-4e1f-a099-089d5fbe503e",
+            description:
+              "Ensure that HEALTHCHECK is being used. The HEALTHCHECK instruction tells Docker how to test a container to check that it is still working",
+            descriptionHTML:
+              "\u003cp\u003eEnsure that HEALTHCHECK is being used. The HEALTHCHECK instruction tells Docker how to test a container to check that it is still working\u003c/p\u003e\n",
+            data: {
+              queryId:
+                "b03a748a-542d-44f4-bb86-9199ab4fd2d5 [Taken from query_id]",
+              queryName: "Healthcheck Instruction Missing",
+              group: "Insecure Configurations [Taken from category]",
+              line: 3,
+              platform: "Dockerfile",
+              issueType: "MissingAttribute",
+              expectedValue: "Dockerfile contains instruction 'HEALTHCHECK'",
+              value: "Dockerfile doesn't contain instruction 'HEALTHCHECK'",
+              filename: "/Dockerfile",
+            },
+            comments: {},
+            vulnerabilityDetails: {
+              cvss: {},
+            },
+          },
+          {
+            type: "kics",
+            label: "IaC Security",
+            id: "150255",
+            similarityId:
+              "bca11aa6fe8840e47585aaa38048073afc521dc953151be020fb8fc4cc38f54a",
+            status: "NEW",
+            state: "TO_VERIFY",
+            severity: "MEDIUM",
+            created: "2022-09-02T10:45:29Z",
+            firstFoundAt: "2022-08-26T10:28:36Z",
+            foundAt: "2022-09-02T10:45:29Z",
+            firstScanId: "cb834dcd-aaec-4e1f-a099-089d5fbe503e",
+            description:
+              "Package version pinning reduces the range of versions that can be installed, reducing the chances of failure due to unanticipated changes",
+            descriptionHTML:
+              "\u003cp\u003ePackage version pinning reduces the range of versions that can be installed, reducing the chances of failure due to unanticipated changes\u003c/p\u003e\n",
+            data: {
+              queryId:
+                "d3499f6d-1651-41bb-a9a7-de925fea487b [Taken from query_id]",
+              queryName: "Unpinned Package Version in Apk Add",
+              group: "Supply-Chain [Taken from category]",
+              line: 6,
+              platform: "Dockerfile",
+              issueType: "IncorrectValue",
+              expectedValue:
+                "RUN instruction with 'apk add \u003cpackage\u003e' should use package pinning form 'apk add \u003cpackage\u003e=\u003cversion\u003e'",
+              value:
+                "RUN instruction apk --no-cache add git python3 py-lxml     \u0026\u0026 rm -rf /var/cache/apk/* does not use package pinning form",
+              filename: "/Dockerfile",
+            },
+            comments: {},
+            vulnerabilityDetails: {
+              cvss: {},
+            },
+          },
+          {
+            type: "sast",
+            label: "sast",
+            id: "255181",
+            similarityId: "-1792929011",
+            status: "NEW",
+            state: "TO_VERIFY",
+            severity: "HIGH",
+            created: "2022-09-02T10:45:54Z",
+            firstFoundAt: "2022-08-26T10:28:57Z",
+            foundAt: "2022-09-02T10:45:54Z",
+            firstScanId: "cb834dcd-aaec-4e1f-a099-089d5fbe503e",
+            description:
+              "The method $PageLoad embeds untrusted data in generated output with echo, at line 11 of /insecure.php. This untrusted data is embedded into the output without proper sanitization or encoding, enabling an attacker to inject malicious code into the generated web-page.\n\nThe attacker would be able to alter the returned web page by simply providing modified data in the user input _POST, which is read by the $PageLoad method at line 10 of /insecure.php. This input then flows through the code straight to the output web page, without sanitization. \r\n\r\nThis can enable a Reflected Cross-Site Scripting (XSS) attack.\n\n",
+            descriptionHTML:
+              "\u003cp\u003eThe method $PageLoad embeds untrusted data in generated output with echo, at line 11 of /insecure.php. This untrusted data is embedded into the output without proper sanitization or encoding, enabling an attacker to inject malicious code into the generated web-page.\u003c/p\u003e\n\n\u003cp\u003eThe attacker would be able to alter the returned web page by simply providing modified data in the user input _POST, which is read by the $PageLoad method at line 10 of /insecure.php. This input then flows through the code straight to the output web page, without sanitization. \r\n\r\nThis can enable a Reflected Cross-Site Scripting (XSS) attack.\u003c/p\u003e\n",
+            data: {
+              // eslint-disable-next-line @typescript-eslint/no-loss-of-precision
+              queryId: 5157925289005576664,
+              queryName: "Reflected_XSS_All_Clients",
+              group: "PHP_High_Risk",
+              resultHash: "ZGJRP6tLG66K4GwKarVTE8GDL/M=",
+              languageName: "PHP",
+              nodes: [
+                {
+                  id: "6BkcV9Pylb1Kk14z/xZHkWcP9hk=",
+                  line: 10,
+                  name: "_POST",
+                  column: 8,
+                  length: 6,
+                  method: "$PageLoad",
+                  nodeID: 164,
+                  domType: "UnknownReference",
+                  fileName: "/insecure.php",
+                  fullName:
+                    "$NS_insecure_a3ce4a23.$Cls_insecure_a3ce4a23._POST",
+                  typeName: "CxDefaultObject",
+                  methodLine: 1,
+                  definitions: "1",
+                },
+                {
+                  id: "o8XLDcRzoLEzVVdI3yyHchg/JH0=",
+                  line: 10,
+                  name: "var",
+                  column: 1,
+                  length: 4,
+                  method: "$PageLoad",
+                  nodeID: 168,
+                  domType: "UnknownReference",
+                  fileName: "/insecure.php",
+                  fullName: "$NS_insecure_a3ce4a23.$Cls_insecure_a3ce4a23.var",
+                  typeName: "CxDefaultObject",
+                  methodLine: 1,
+                  definitions: "1",
+                },
+                {
+                  id: "yis1SnpLBtDSuxZBPhw76TaDjY4=",
+                  line: 11,
+                  name: "var",
+                  column: 12,
+                  length: 4,
+                  method: "$PageLoad",
+                  nodeID: 184,
+                  domType: "UnknownReference",
+                  fileName: "/insecure.php",
+                  fullName: "$NS_insecure_a3ce4a23.$Cls_insecure_a3ce4a23.var",
+                  typeName: "CxDefaultObject",
+                  methodLine: 1,
+                  definitions: "1",
+                },
+                {
+                  id: "kZuPO2VpUX+yVNtYvSP3FVHVJBQ=",
+                  line: 11,
+                  name: "$_DoubleQuotedString",
+                  column: 0,
+                  length: 20,
+                  method: "$PageLoad",
+                  nodeID: 177,
+                  domType: "MethodInvokeExpr",
+                  fileName: "/insecure.php",
+                  fullName: "$_DoubleQuotedString",
+                  typeName: "$_DoubleQuotedString",
+                  methodLine: 1,
+                  definitions: "0",
+                },
+                {
+                  id: "fO7BgAMUgzMTXcmTFe9v8TGpYPg=",
+                  line: 11,
+                  name: "echo",
+                  column: 1,
+                  length: 4,
+                  method: "$PageLoad",
+                  nodeID: 171,
+                  domType: "MethodInvokeExpr",
+                  fileName: "/insecure.php",
+                  fullName: "echo",
+                  typeName: "echo",
+                  methodLine: 1,
+                  definitions: "0",
+                },
+              ],
+            },
+            comments: {},
+            vulnerabilityDetails: {
+              cweId: 79,
+              cvss: {},
+              compliances: [
+                "PCI DSS v3.2.1",
+                "ASD STIG 4.10",
+                "FISMA 2014",
+                "NIST SP 800-53",
+                "OWASP Top 10 2013",
+                "OWASP Top 10 2017",
+                "OWASP Top 10 2021",
+              ],
+            },
+          },
+          {
+            type: "sast",
+            label: "sast",
+            id: "255181",
+            similarityId: "-1792929011",
+            status: "NEW",
+            state: "TO_VERIFY",
+            severity: "CRITICAL",
+            created: "2022-09-02T10:45:54Z",
+            firstFoundAt: "2022-08-26T10:28:57Z",
+            foundAt: "2022-09-02T10:45:54Z",
+            firstScanId: "cb834dcd-aaec-4e1f-a099-089d5fbe503e",
+            description:
+              "The method $PageLoad embeds untrusted data in generated output with echo, at line 11 of /insecure.php. This untrusted data is embedded into the output without proper sanitization or encoding, enabling an attacker to inject malicious code into the generated web-page.\n\nThe attacker would be able to alter the returned web page by simply providing modified data in the user input _POST, which is read by the $PageLoad method at line 10 of /insecure.php. This input then flows through the code straight to the output web page, without sanitization. \r\n\r\nThis can enable a Reflected Cross-Site Scripting (XSS) attack.\n\n",
+            descriptionHTML:
+              "\u003cp\u003eThe method $PageLoad embeds untrusted data in generated output with echo, at line 11 of /insecure.php. This untrusted data is embedded into the output without proper sanitization or encoding, enabling an attacker to inject malicious code into the generated web-page.\u003c/p\u003e\n\n\u003cp\u003eThe attacker would be able to alter the returned web page by simply providing modified data in the user input _POST, which is read by the $PageLoad method at line 10 of /insecure.php. This input then flows through the code straight to the output web page, without sanitization. \r\n\r\nThis can enable a Reflected Cross-Site Scripting (XSS) attack.\u003c/p\u003e\n",
+            data: {
+              // eslint-disable-next-line @typescript-eslint/no-loss-of-precision
+              queryId: 5157925289005576664,
+              queryName: "Reflected_XSS_All_Clients",
+              group: "PHP_High_Risk",
+              resultHash: "ZGJRP6tLG66K4GwKarVTE8GDL/M=",
+              languageName: "PHP",
+              nodes: [
+                {
+                  id: "6BkcV9Pylb1Kk14z/xZHkWcP9hk=",
+                  line: 10,
+                  name: "_POST",
+                  column: 8,
+                  length: 6,
+                  method: "$PageLoad",
+                  nodeID: 164,
+                  domType: "UnknownReference",
+                  fileName: "/insecure.php",
+                  fullName:
+                    "$NS_insecure_a3ce4a23.$Cls_insecure_a3ce4a23._POST",
+                  typeName: "CxDefaultObject",
+                  methodLine: 1,
+                  definitions: "1",
+                },
+                {
+                  id: "o8XLDcRzoLEzVVdI3yyHchg/JH0=",
+                  line: 10,
+                  name: "var",
+                  column: 1,
+                  length: 4,
+                  method: "$PageLoad",
+                  nodeID: 168,
+                  domType: "UnknownReference",
+                  fileName: "/insecure.php",
+                  fullName: "$NS_insecure_a3ce4a23.$Cls_insecure_a3ce4a23.var",
+                  typeName: "CxDefaultObject",
+                  methodLine: 1,
+                  definitions: "1",
+                },
+                {
+                  id: "yis1SnpLBtDSuxZBPhw76TaDjY4=",
+                  line: 11,
+                  name: "var",
+                  column: 12,
+                  length: 4,
+                  method: "$PageLoad",
+                  nodeID: 184,
+                  domType: "UnknownReference",
+                  fileName: "/insecure.php",
+                  fullName: "$NS_insecure_a3ce4a23.$Cls_insecure_a3ce4a23.var",
+                  typeName: "CxDefaultObject",
+                  methodLine: 1,
+                  definitions: "1",
+                },
+                {
+                  id: "kZuPO2VpUX+yVNtYvSP3FVHVJBQ=",
+                  line: 11,
+                  name: "$_DoubleQuotedString",
+                  column: 0,
+                  length: 20,
+                  method: "$PageLoad",
+                  nodeID: 177,
+                  domType: "MethodInvokeExpr",
+                  fileName: "/insecure.php",
+                  fullName: "$_DoubleQuotedString",
+                  typeName: "$_DoubleQuotedString",
+                  methodLine: 1,
+                  definitions: "0",
+                },
+                {
+                  id: "fO7BgAMUgzMTXcmTFe9v8TGpYPg=",
+                  line: 11,
+                  name: "echo",
+                  column: 1,
+                  length: 4,
+                  method: "$PageLoad",
+                  nodeID: 171,
+                  domType: "MethodInvokeExpr",
+                  fileName: "/insecure.php",
+                  fullName: "echo",
+                  typeName: "echo",
+                  methodLine: 1,
+                  definitions: "0",
+                },
+              ],
+            },
+            comments: {},
+            vulnerabilityDetails: {
+              cweId: 79,
+              cvss: {},
+              compliances: [
+                "PCI DSS v3.2.1",
+                "ASD STIG 4.10",
+                "FISMA 2014",
+                "NIST SP 800-53",
+                "OWASP Top 10 2013",
+                "OWASP Top 10 2017",
+                "OWASP Top 10 2021",
+              ],
+            },
+          },
+          {
+            type: "sca",
+            scaType: "Vulnerability",
+            label: "sca",
+            id: "cve-2011-3374",
+            similarityId: "cve-2011-3374",
+            status: "RECURRENT",
+            state: "TO_VERIFY",
+            severity: "LOW",
+            created: "2023-04-21T10:34:40Z",
+            firstFoundAt: "2023-02-23T12:19:31Z",
+            foundAt: "2023-04-21T10:34:40Z",
+            firstScanId: "eaa0f3ea-ce32-4059-9836-db13d16fb2c8",
+            description:
+              "It was found that apt-key in apt, all versions, do not correctly validate gpg keys with the master keyring, leading to a potential man-in-the-middle attack.",
+            descriptionHTML:
+              "\u003cp\u003eIt was found that apt-key in apt, all versions, do not correctly validate gpg keys with the master keyring, leading to a potential man-in-the-middle attack.\u003c/p\u003e\n",
+            data: {},
+            comments: {},
+            vulnerabilityDetails: {
+              cweId: "CWE-347",
+              cvssScore: 3.7,
+              cvss: {
+                version: 3,
+                attackVector: "NETWORK",
+                availability: "NONE",
+                confidentiality: "NONE",
+                attackComplexity: "HIGH",
+              },
+            },
+          },
+          {
+            type: "sscs-secret-detection",
+            id: "49zX0DLkU5pXNroqUZ8IM57sO5U=",
+            similarityId:
+              "7dd5481569c41f10fa3eff060673446480940fbc853b960b5b240029088ce639",
+            status: "NEW",
+            state: "TO_VERIFY",
+            severity: "HIGH",
+            confidenceLevel: 0,
+            created: "2024-09-06T12:15:06Z",
+            firstFoundAt: "2024-09-06T12:15:06Z",
+            foundAt: "2024-09-06T12:15:06Z",
+            firstScanId: "b57170dc-fb77-442b-a9b5-0f788654b8ee",
+            description: "jwt has detected secret for file /secrets.go.",
+            data: {
+              ruleId: "jwt",
+              ruleName: "Jwt",
+              fileName: "/secrets.go",
+              line: 12,
+              snippet: "eyJh***",
+              slsaStep: "Source",
+              ruleDescription:
+                "Uncovered a JSON Web Token, which may lead to unauthorized access to web applications and sensitive user data.",
+              remediation: "Remove secret",
+              remediationLink: null,
+              remediationAdditional:
+                "Remove or mask the secret value shown in your file/artifact. If your secret is still valid, you should revoke it, in order to prevent malicious use of compromised secrets.",
+              validity: "Unknown",
+            },
+            comments: {},
+            vulnerabilityDetails: {},
+          },
+          {
+            type: "sscs-scorecard",
+            id: "/5o5sN0v5K2I8J934plrSE6A8RQ=",
+            similarityId:
+              "c7b19748c8985c3717885512828eb8b43962af069a71543fd7354c12f291dadc",
+            status: "NEW",
+            state: "TO_VERIFY",
+            severity: "HIGH",
+            confidenceLevel: 0,
+            created: "2024-09-06T12:15:06Z",
+            firstFoundAt: "2024-09-06T12:15:06Z",
+            foundAt: "2024-09-06T12:15:06Z",
+            firstScanId: "b57170dc-fb77-442b-a9b5-0f788654b8ee",
+            description:
+              "score is 0: no update tool detected:\nWarn: tool 'RenovateBot' is not used\nWarn: tool 'Dependabot' is not used\nWarn: tool 'PyUp' is not used",
+            data: {
+              ruleId: "DependencyUpdateToolID",
+              ruleName: "Dependency-Update-Tool",
+              fileName: "Issue Found in your GitHub repository",
+              line: 1,
+              snippet: null,
+              slsaStep: "Dependencies",
+              ruleDescription:
+                "Determines if the project uses a dependency update tool.",
+              remediation:
+                "Implement the remediation recommendations provided in the URL",
+              remediationLink:
+                "https://github.com/ossf/scorecard/blob/main/docs/checks.md#dependency-update-tool",
+              remediationAdditional: null,
+              validity: null,
+            },
+            comments: {},
+            vulnerabilityDetails: {},
+          },
+          {
+            type: "sscs-scorecard",
+            id: "A1hsrnELDUxAcOtjBGsP6GtlEBA=",
+            similarityId:
+              "023c7542148f63613c00f016af227e6aa5e8c617d7ca53e7522feaf91539249f",
+            status: "NEW",
+            state: "TO_VERIFY",
+            severity: "HIGH",
+            confidenceLevel: 0,
+            created: "2024-09-06T12:15:06Z",
+            firstFoundAt: "2024-09-06T12:15:06Z",
+            foundAt: "2024-09-06T12:15:06Z",
+            firstScanId: "b57170dc-fb77-442b-a9b5-0f788654b8ee",
+            description:
+              "score is 0: 1 commit(s) and 0 issue activity found in the last 90 days -- score normalized to 0",
+            data: {
+              ruleId: "MaintainedID",
+              ruleName: "Maintained",
+              fileName: "Issue Found in your GitHub repository",
+              line: 1,
+              snippet: null,
+              slsaStep: "Source",
+              ruleDescription:
+                'Determines if the project is "actively maintained".',
+              remediation:
+                "Implement the remediation recommendations provided in the URL",
+              remediationLink:
+                "https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained",
+              remediationAdditional: null,
+              validity: null,
+            },
+            comments: {},
+            vulnerabilityDetails: {},
+          },
+          {
+            type: "sscs-secret-detection",
+            id: "AtXoUC0MXjbfw9pmPtR8LbsdvXk=",
+            similarityId:
+              "4a6ddb4a8d5a9cbcbc8b4c45d35e710bd753b1cb824e594fc0c44831273fa53e",
+            status: "NEW",
+            state: "TO_VERIFY",
+            severity: "HIGH",
+            confidenceLevel: 0,
+            created: "2024-09-06T12:15:06Z",
+            firstFoundAt: "2024-09-06T12:15:06Z",
+            foundAt: "2024-09-06T12:15:06Z",
+            firstScanId: "b57170dc-fb77-442b-a9b5-0f788654b8ee",
+            description:
+              "stripe-access-token has detected secret for file /secrets.go.",
+            data: {
+              ruleId: "stripe-access-token",
+              ruleName: "Stripe-Access-Token",
+              fileName: "/secrets.go",
+              line: 6,
+              snippet: "sk_t***",
+              slsaStep: "Source",
+              ruleDescription:
+                "Found a Stripe Access Token, posing a risk to payment processing services and sensitive financial data.",
+              remediation: "Remove secret",
+              remediationLink: null,
+              remediationAdditional:
+                "Remove or mask the secret value shown in your file/artifact. If your secret is still valid, you should revoke it, in order to prevent malicious use of compromised secrets.",
+              validity: "Unknown",
+            },
+            comments: {},
+            vulnerabilityDetails: {},
+          },
+          {
+            type: "sscs-scorecard",
+            id: "hJTinqcw2jva0HvKrXSM1hU3cgk=",
+            similarityId:
+              "23fa634d6ae404d07586c36f4bb7eee8682805ed003e514354f89408eb0d840d",
+            status: "NEW",
+            state: "TO_VERIFY",
+            severity: "LOW",
+            confidenceLevel: 0,
+            created: "2024-09-06T12:15:06Z",
+            firstFoundAt: "2024-09-06T12:15:06Z",
+            foundAt: "2024-09-06T12:15:06Z",
+            firstScanId: "b57170dc-fb77-442b-a9b5-0f788654b8ee",
+            description:
+              "score is 0: no effort to earn an OpenSSF best practices badge detected",
+            data: {
+              ruleId: "CIIBestPracticesID",
+              ruleName: "CII-Best-Practices",
+              fileName: "Issue Found in your GitHub repository",
+              line: 1,
+              snippet: null,
+              slsaStep: "Source",
+              ruleDescription:
+                "Determines if the project has an OpenSSF (formerly CII) Best Practices Badge.",
+              remediation:
+                "Implement the remediation recommendations provided in the URL",
+              remediationLink:
+                "https://github.com/ossf/scorecard/blob/main/docs/checks.md#cii-best-practices",
+              remediationAdditional: null,
+              validity: null,
+            },
+            comments: {},
+            vulnerabilityDetails: {},
+          },
+          {
+            type: "sscs-scorecard",
+            id: "hzIL93W8mGkglJVJvtU5LWPFWCs=",
+            similarityId:
+              "ff67df300cd3e181ce0d5c11534f17b05d1634427c0974737645fe6140546b7b",
+            status: "NEW",
+            state: "TO_VERIFY",
+            severity: "HIGH",
+            confidenceLevel: 0,
+            created: "2024-09-06T12:15:06Z",
+            firstFoundAt: "2024-09-06T12:15:06Z",
+            foundAt: "2024-09-06T12:15:06Z",
+            firstScanId: "b57170dc-fb77-442b-a9b5-0f788654b8ee",
+            description:
+              "score is 0: branch protection not enabled on development/release branches:\nWarn: branch protection not enabled for branch 'main'",
+            data: {
+              ruleId: "BranchProtectionID",
+              ruleName: "Branch-Protection",
+              fileName: "Issue Found in your GitHub repository",
+              line: 1,
+              snippet: null,
+              slsaStep: "Source",
+              ruleDescription:
+                "Determines if the default and release branches are protected with GitHub's branch protection settings.",
+              remediation:
+                "Implement the remediation recommendations provided in the URL",
+              remediationLink:
+                "https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection",
+              remediationAdditional: null,
+              validity: null,
+            },
+            comments: {},
+            vulnerabilityDetails: {},
+          },
+          {
+            type: "sscs-secret-detection",
+            id: "JiP6l2/7A1eZy/IJw5xb0K773VY=",
+            similarityId:
+              "7dd5481569c41f10fa3eff060673446480940fbc853b960b5b240029088ce639",
+            status: "NEW",
+            state: "TO_VERIFY",
+            severity: "HIGH",
+            confidenceLevel: 0,
+            created: "2024-09-06T12:15:06Z",
+            firstFoundAt: "2024-09-06T12:15:06Z",
+            foundAt: "2024-09-06T12:15:06Z",
+            firstScanId: "b57170dc-fb77-442b-a9b5-0f788654b8ee",
+            description: "jwt has detected secret for file /secrets.go.",
+            data: {
+              ruleId: "jwt",
+              ruleName: "Jwt",
+              fileName: "/secrets.go",
+              line: 31,
+              snippet: "eyJh***",
+              slsaStep: "Source",
+              ruleDescription:
+                "Uncovered a JSON Web Token, which may lead to unauthorized access to web applications and sensitive user data.",
+              remediation: "Remove secret",
+              remediationLink: null,
+              remediationAdditional:
+                "Remove or mask the secret value shown in your file/artifact. If your secret is still valid, you should revoke it, in order to prevent malicious use of compromised secrets.",
+              validity: "Unknown",
+            },
+            comments: {},
+            vulnerabilityDetails: {},
+          },
+          {
+            type: "sscs-secret-detection",
+            id: "jIQToNyflbBa1oNDxw9KL/tRsJA=",
+            similarityId:
+              "a28bc5175d1eea7caca193f7e419d331b063de90005eb0dee86caf5beaf5efef",
+            status: "NEW",
+            state: "TO_VERIFY",
+            severity: "HIGH",
+            confidenceLevel: 0,
+            created: "2024-09-06T12:15:06Z",
+            firstFoundAt: "2024-09-06T12:15:06Z",
+            foundAt: "2024-09-06T12:15:06Z",
+            firstScanId: "b57170dc-fb77-442b-a9b5-0f788654b8ee",
+            description:
+              "aws-access-token has detected secret for file /secrets.go.",
+            data: {
+              ruleId: "aws-access-token",
+              ruleName: "Aws-Access-Token",
+              fileName: "/secrets.go",
+              line: 24,
+              snippet: "AKIA***",
+              slsaStep: "Source",
+              ruleDescription:
+                "Identified a pattern that may indicate AWS credentials, risking unauthorized cloud resource access and data breaches on AWS platforms.",
+              remediation: "Remove secret",
+              remediationLink: null,
+              remediationAdditional:
+                "Remove or mask the secret value shown in your file/artifact. If your secret is still valid, you should revoke it, in order to prevent malicious use of compromised secrets.",
+              validity: "Unknown",
+            },
+            comments: {},
+            vulnerabilityDetails: {},
+          },
+          {
+            type: "sscs-scorecard",
+            id: "lPQHovRXLnCOS084YFJztmmOgUs=",
+            similarityId:
+              "6012016a4cf3c90eb32ccc1f002be3df48fd50c564a258b66b68d41102deabcf",
+            status: "NEW",
+            state: "TO_VERIFY",
+            severity: "MEDIUM",
+            confidenceLevel: 0,
+            created: "2024-09-06T12:15:06Z",
+            firstFoundAt: "2024-09-06T12:15:06Z",
+            foundAt: "2024-09-06T12:15:06Z",
+            firstScanId: "b57170dc-fb77-442b-a9b5-0f788654b8ee",
+            description:
+              "score is 0: security policy file not detected:\nWarn: no security policy file detected\nWarn: no security file to analyze\nWarn: no security file to analyze\nWarn: no security file to analyze",
+            data: {
+              ruleId: "SecurityPolicyID",
+              ruleName: "Security-Policy",
+              fileName: "Issue Found in your GitHub repository",
+              line: 1,
+              snippet: null,
+              slsaStep: "Source",
+              ruleDescription:
+                "Determines if the project has published a security policy.",
+              remediation:
+                "Implement the remediation recommendations provided in the URL",
+              remediationLink:
+                "https://github.com/ossf/scorecard/blob/main/docs/checks.md#security-policy",
+              remediationAdditional: null,
+              validity: null,
+            },
+            comments: {},
+            vulnerabilityDetails: {},
+          },
+          {
+            type: "sscs-scorecard",
+            id: "NEz6oBIVFxHpCSKo5eXrva9Kk9A=",
+            similarityId:
+              "0475e70493b2eb38b92c8379ab51b0e7ca99732f0de79d09973931be8c439228",
+            status: "NEW",
+            state: "TO_VERIFY",
+            severity: "HIGH",
+            confidenceLevel: 0,
+            created: "2024-09-06T12:15:06Z",
+            firstFoundAt: "2024-09-06T12:15:06Z",
+            foundAt: "2024-09-06T12:15:06Z",
+            firstScanId: "b57170dc-fb77-442b-a9b5-0f788654b8ee",
+            description:
+              "score is 0: found 2 unreviewed changesets out of 2 -- score normalized to 0",
+            data: {
+              ruleId: "CodeReviewID",
+              ruleName: "Code-Review",
+              fileName: "Issue Found in your GitHub repository",
+              line: 1,
+              snippet: null,
+              slsaStep: "Source",
+              ruleDescription:
+                "Determines if the project requires human code review before pull requests (aka merge requests) are merged.",
+              remediation:
+                "Implement the remediation recommendations provided in the URL",
+              remediationLink:
+                "https://github.com/ossf/scorecard/blob/main/docs/checks.md#code-review",
+              remediationAdditional: null,
+              validity: null,
+            },
+            comments: {},
+            vulnerabilityDetails: {},
+          },
+          {
+            type: "sscs-secret-detection",
+            id: "qKGhcZ6Jd5mm4KaMTvg7c5d/+ro=",
+            similarityId:
+              "a28bc5175d1eea7caca193f7e419d331b063de90005eb0dee86caf5beaf5efef",
+            status: "NEW",
+            state: "TO_VERIFY",
+            severity: "HIGH",
+            confidenceLevel: 0,
+            created: "2024-09-06T12:15:06Z",
+            firstFoundAt: "2024-09-06T12:15:06Z",
+            foundAt: "2024-09-06T12:15:06Z",
+            firstScanId: "b57170dc-fb77-442b-a9b5-0f788654b8ee",
+            description:
+              "aws-access-token has detected secret for file /secrets.go.",
+            data: {
+              ruleId: "aws-access-token",
+              ruleName: "Aws-Access-Token",
+              fileName: "/secrets.go",
+              line: 9,
+              snippet: "AKIA***",
+              slsaStep: "Source",
+              ruleDescription:
+                "Identified a pattern that may indicate AWS credentials, risking unauthorized cloud resource access and data breaches on AWS platforms.",
+              remediation: "Remove secret",
+              remediationLink: null,
+              remediationAdditional:
+                "Remove or mask the secret value shown in your file/artifact. If your secret is still valid, you should revoke it, in order to prevent malicious use of compromised secrets.",
+              validity: "Unknown",
+            },
+            comments: {},
+            vulnerabilityDetails: {},
+          },
+          {
+            type: "sscs-secret-detection",
+            id: "TJWZcBouTD0JnYWO52XdEkQ2lpA=",
+            similarityId:
+              "4a6ddb4a8d5a9cbcbc8b4c45d35e710bd753b1cb824e594fc0c44831273fa53e",
+            status: "NEW",
+            state: "TO_VERIFY",
+            severity: "HIGH",
+            confidenceLevel: 0,
+            created: "2024-09-06T12:15:06Z",
+            firstFoundAt: "2024-09-06T12:15:06Z",
+            foundAt: "2024-09-06T12:15:06Z",
+            firstScanId: "b57170dc-fb77-442b-a9b5-0f788654b8ee",
+            description:
+              "stripe-access-token has detected secret for file /secrets.go.",
+            data: {
+              ruleId: "stripe-access-token",
+              ruleName: "Stripe-Access-Token",
+              fileName: "/secrets.go",
+              line: 15,
+              snippet: "sk_t***",
+              slsaStep: "Source",
+              ruleDescription:
+                "Found a Stripe Access Token, posing a risk to payment processing services and sensitive financial data.",
+              remediation: "Remove secret",
+              remediationLink: null,
+              remediationAdditional:
+                "Remove or mask the secret value shown in your file/artifact. If your secret is still valid, you should revoke it, in order to prevent malicious use of compromised secrets.",
+              validity: "Unknown",
+            },
+            comments: {},
+            vulnerabilityDetails: {},
+          },
+          {
+            type: "sscs-scorecard",
+            id: "tPes1zHT9L1Q5AP8T9iC5vZBG9U=",
+            similarityId:
+              "da8f116022d814a1d338444a27719a71e19cb3083bd6fe618649a00878ae8c25",
+            status: "NEW",
+            state: "TO_VERIFY",
+            severity: "MEDIUM",
+            confidenceLevel: 0,
+            created: "2024-09-06T12:15:06Z",
+            firstFoundAt: "2024-09-06T12:15:06Z",
+            foundAt: "2024-09-06T12:15:06Z",
+            firstScanId: "b57170dc-fb77-442b-a9b5-0f788654b8ee",
+            description:
+              "score is 0: project is not fuzzed:\nWarn: no OSSFuzz integration found\nWarn: no GoBuiltInFuzzer integration found\nWarn: no PythonAtherisFuzzer integration found\nWarn: no CLibFuzzer integration found\nWarn: no CppLibFuzzer integration found\nWarn: no SwiftLibFuzzer integration found\nWarn: no RustCargoFuzzer integration found\nWarn: no JavaJazzerFuzzer integration found\nWarn: no ClusterFuzzLite integration found\nWarn: no HaskellPropertyBasedTesting integration found\nWarn: no TypeScriptPropertyBasedTesting integration found\nWarn: no JavaScriptPropertyBasedTesting integration found",
+            data: {
+              ruleId: "FuzzingID",
+              ruleName: "Fuzzing",
+              fileName: "Issue Found in your GitHub repository",
+              line: 1,
+              snippet: null,
+              slsaStep: "Package",
+              ruleDescription: "Determines if the project uses fuzzing.",
+              remediation:
+                "Implement the remediation recommendations provided in the URL",
+              remediationLink:
+                "https://github.com/ossf/scorecard/blob/main/docs/checks.md#fuzzing",
+              remediationAdditional: null,
+              validity: null,
+            },
+            comments: {},
+            vulnerabilityDetails: {},
+          },
+          {
+            type: "sscs-secret-detection",
+            id: "yfZPTrZsBH5X3BpleyRKUDS10BM=",
+            similarityId:
+              "0870b429f0107daadc62c70e36cbb47683a7605b38a76b32922e3e0ac6f85f85",
+            status: "NEW",
+            state: "TO_VERIFY",
+            severity: "HIGH",
+            confidenceLevel: 0,
+            created: "2024-09-06T12:15:06Z",
+            firstFoundAt: "2024-09-06T12:15:06Z",
+            foundAt: "2024-09-06T12:15:06Z",
+            firstScanId: "b57170dc-fb77-442b-a9b5-0f788654b8ee",
+            description:
+              "generic-api-key has detected secret for file /secrets.go.",
+            data: {
+              ruleId: "generic-api-key",
+              ruleName: "Generic-Api-Key",
+              fileName: "/secrets.go",
+              line: 10,
+              snippet: "abc1***",
+              slsaStep: "Source",
+              ruleDescription:
+                "Detected a Generic API Key, potentially exposing access to various services and sensitive operations.",
+              remediation: "Remove secret",
+              remediationLink: null,
+              remediationAdditional:
+                "Remove or mask the secret value shown in your file/artifact. If your secret is still valid, you should revoke it, in order to prevent malicious use of compromised secrets.",
+              validity: "Unknown",
+            },
+            comments: {},
+            vulnerabilityDetails: {},
+          },
+        ],
+      };
+    }
+    writeFileSync(
+      getFilePath() + "/ast-results.json",
+      JSON.stringify(results),
+      {
+        flag: "w+",
+      }
+    );
+  }
 
-	async getResults(scanId: string) {
-		let results;
+  async getScan(scanId: string): Promise<CxScan | undefined> {
+    if (scanId === EMPTY_RESULTS_SCAN_ID) {
+      return {
+        tags: {},
+        groups: undefined,
+        id: EMPTY_RESULTS_SCAN_ID,
+        projectID: "EmptyResultsProjectId",
+        status: "Completed",
+        createdAt: "2023-03-19T15:10:38.749899+01:00",
+        updatedAt: "2023-03-19T14:11:42.892326Z",
+        origin: "grpc-java-netty 1.35.0",
+        initiator: "tester",
+        branch: "main",
+      };
+    }
+    return {
+      tags: {},
+      groups: undefined,
+      id: "1",
+      projectID: "2588deba-1751-4afc-b7e3-db71727a1edd",
+      status: "Completed",
+      createdAt: "2023-04-19T10:07:37.628413+01:00",
+      updatedAt: "2023-04-19T09:08:27.151913Z",
+      origin: "grpc-java-netty 1.35.0",
+      initiator: "tiago",
+      branch: "main",
+    };
+  }
 
-		if (scanId === "2" || scanId === EMPTY_RESULTS_SCAN_ID) {
-			results = {
-				"results": []
-			};
-		}
-		else {
-			results = {
-				"results": [
-					{
-						"type": "kics",
-						"label": "IaC Security",
-						"id": "150256",
-						"similarityId": "92742543fa8505b3ba24ff54894c94594d0d9e3873b05fb38dbcbdef40aa3062",
-						"status": "NEW",
-						"state": "TO_VERIFY",
-						"severity": "LOW",
-						"created": "2022-09-02T10:45:29Z",
-						"firstFoundAt": "2022-08-26T10:28:36Z",
-						"foundAt": "2022-09-02T10:45:29Z",
-						"firstScanId": "cb834dcd-aaec-4e1f-a099-089d5fbe503e",
-						"description": "Ensure that HEALTHCHECK is being used. The HEALTHCHECK instruction tells Docker how to test a container to check that it is still working",
-						"descriptionHTML": "\u003cp\u003eEnsure that HEALTHCHECK is being used. The HEALTHCHECK instruction tells Docker how to test a container to check that it is still working\u003c/p\u003e\n",
-						"data": {
-							"queryId": "b03a748a-542d-44f4-bb86-9199ab4fd2d5 [Taken from query_id]",
-							"queryName": "Healthcheck Instruction Missing",
-							"group": "Insecure Configurations [Taken from category]",
-							"line": 3,
-							"platform": "Dockerfile",
-							"issueType": "MissingAttribute",
-							"expectedValue": "Dockerfile contains instruction 'HEALTHCHECK'",
-							"value": "Dockerfile doesn't contain instruction 'HEALTHCHECK'",
-							"filename": "/Dockerfile"
-						},
-						"comments": {},
-						"vulnerabilityDetails": {
-							"cvss": {}
-						}
-					},
-					{
-						"type": "kics",
-						"label": "IaC Security",
-						"id": "150255",
-						"similarityId": "bca11aa6fe8840e47585aaa38048073afc521dc953151be020fb8fc4cc38f54a",
-						"status": "NEW",
-						"state": "TO_VERIFY",
-						"severity": "MEDIUM",
-						"created": "2022-09-02T10:45:29Z",
-						"firstFoundAt": "2022-08-26T10:28:36Z",
-						"foundAt": "2022-09-02T10:45:29Z",
-						"firstScanId": "cb834dcd-aaec-4e1f-a099-089d5fbe503e",
-						"description": "Package version pinning reduces the range of versions that can be installed, reducing the chances of failure due to unanticipated changes",
-						"descriptionHTML": "\u003cp\u003ePackage version pinning reduces the range of versions that can be installed, reducing the chances of failure due to unanticipated changes\u003c/p\u003e\n",
-						"data": {
-							"queryId": "d3499f6d-1651-41bb-a9a7-de925fea487b [Taken from query_id]",
-							"queryName": "Unpinned Package Version in Apk Add",
-							"group": "Supply-Chain [Taken from category]",
-							"line": 6,
-							"platform": "Dockerfile",
-							"issueType": "IncorrectValue",
-							"expectedValue": "RUN instruction with 'apk add \u003cpackage\u003e' should use package pinning form 'apk add \u003cpackage\u003e=\u003cversion\u003e'",
-							"value": "RUN instruction apk --no-cache add git python3 py-lxml     \u0026\u0026 rm -rf /var/cache/apk/* does not use package pinning form",
-							"filename": "/Dockerfile"
-						},
-						"comments": {},
-						"vulnerabilityDetails": {
-							"cvss": {}
-						}
-					},
-					{
-						"type": "sast",
-						"label": "sast",
-						"id": "255181",
-						"similarityId": "-1792929011",
-						"status": "NEW",
-						"state": "TO_VERIFY",
-						"severity": "HIGH",
-						"created": "2022-09-02T10:45:54Z",
-						"firstFoundAt": "2022-08-26T10:28:57Z",
-						"foundAt": "2022-09-02T10:45:54Z",
-						"firstScanId": "cb834dcd-aaec-4e1f-a099-089d5fbe503e",
-						"description": "The method $PageLoad embeds untrusted data in generated output with echo, at line 11 of /insecure.php. This untrusted data is embedded into the output without proper sanitization or encoding, enabling an attacker to inject malicious code into the generated web-page.\n\nThe attacker would be able to alter the returned web page by simply providing modified data in the user input _POST, which is read by the $PageLoad method at line 10 of /insecure.php. This input then flows through the code straight to the output web page, without sanitization. \r\n\r\nThis can enable a Reflected Cross-Site Scripting (XSS) attack.\n\n",
-						"descriptionHTML": "\u003cp\u003eThe method $PageLoad embeds untrusted data in generated output with echo, at line 11 of /insecure.php. This untrusted data is embedded into the output without proper sanitization or encoding, enabling an attacker to inject malicious code into the generated web-page.\u003c/p\u003e\n\n\u003cp\u003eThe attacker would be able to alter the returned web page by simply providing modified data in the user input _POST, which is read by the $PageLoad method at line 10 of /insecure.php. This input then flows through the code straight to the output web page, without sanitization. \r\n\r\nThis can enable a Reflected Cross-Site Scripting (XSS) attack.\u003c/p\u003e\n",
-						"data": {
-							// eslint-disable-next-line @typescript-eslint/no-loss-of-precision
-							"queryId": 5157925289005576664,
-							"queryName": "Reflected_XSS_All_Clients",
-							"group": "PHP_High_Risk",
-							"resultHash": "ZGJRP6tLG66K4GwKarVTE8GDL/M=",
-							"languageName": "PHP",
-							"nodes": [
-								{
-									"id": "6BkcV9Pylb1Kk14z/xZHkWcP9hk=",
-									"line": 10,
-									"name": "_POST",
-									"column": 8,
-									"length": 6,
-									"method": "$PageLoad",
-									"nodeID": 164,
-									"domType": "UnknownReference",
-									"fileName": "/insecure.php",
-									"fullName": "$NS_insecure_a3ce4a23.$Cls_insecure_a3ce4a23._POST",
-									"typeName": "CxDefaultObject",
-									"methodLine": 1,
-									"definitions": "1"
-								},
-								{
-									"id": "o8XLDcRzoLEzVVdI3yyHchg/JH0=",
-									"line": 10,
-									"name": "var",
-									"column": 1,
-									"length": 4,
-									"method": "$PageLoad",
-									"nodeID": 168,
-									"domType": "UnknownReference",
-									"fileName": "/insecure.php",
-									"fullName": "$NS_insecure_a3ce4a23.$Cls_insecure_a3ce4a23.var",
-									"typeName": "CxDefaultObject",
-									"methodLine": 1,
-									"definitions": "1"
-								},
-								{
-									"id": "yis1SnpLBtDSuxZBPhw76TaDjY4=",
-									"line": 11,
-									"name": "var",
-									"column": 12,
-									"length": 4,
-									"method": "$PageLoad",
-									"nodeID": 184,
-									"domType": "UnknownReference",
-									"fileName": "/insecure.php",
-									"fullName": "$NS_insecure_a3ce4a23.$Cls_insecure_a3ce4a23.var",
-									"typeName": "CxDefaultObject",
-									"methodLine": 1,
-									"definitions": "1"
-								},
-								{
-									"id": "kZuPO2VpUX+yVNtYvSP3FVHVJBQ=",
-									"line": 11,
-									"name": "$_DoubleQuotedString",
-									"column": 0,
-									"length": 20,
-									"method": "$PageLoad",
-									"nodeID": 177,
-									"domType": "MethodInvokeExpr",
-									"fileName": "/insecure.php",
-									"fullName": "$_DoubleQuotedString",
-									"typeName": "$_DoubleQuotedString",
-									"methodLine": 1,
-									"definitions": "0"
-								},
-								{
-									"id": "fO7BgAMUgzMTXcmTFe9v8TGpYPg=",
-									"line": 11,
-									"name": "echo",
-									"column": 1,
-									"length": 4,
-									"method": "$PageLoad",
-									"nodeID": 171,
-									"domType": "MethodInvokeExpr",
-									"fileName": "/insecure.php",
-									"fullName": "echo",
-									"typeName": "echo",
-									"methodLine": 1,
-									"definitions": "0"
-								}
-							]
-						},
-						"comments": {},
-						"vulnerabilityDetails": {
-							"cweId": 79,
-							"cvss": {},
-							"compliances": [
-								"PCI DSS v3.2.1",
-								"ASD STIG 4.10",
-								"FISMA 2014",
-								"NIST SP 800-53",
-								"OWASP Top 10 2013",
-								"OWASP Top 10 2017",
-								"OWASP Top 10 2021"
-							]
-						}
-					},
-					{
-						"type": "sast",
-						"label": "sast",
-						"id": "255181",
-						"similarityId": "-1792929011",
-						"status": "NEW",
-						"state": "TO_VERIFY",
-						"severity": "CRITICAL",
-						"created": "2022-09-02T10:45:54Z",
-						"firstFoundAt": "2022-08-26T10:28:57Z",
-						"foundAt": "2022-09-02T10:45:54Z",
-						"firstScanId": "cb834dcd-aaec-4e1f-a099-089d5fbe503e",
-						"description": "The method $PageLoad embeds untrusted data in generated output with echo, at line 11 of /insecure.php. This untrusted data is embedded into the output without proper sanitization or encoding, enabling an attacker to inject malicious code into the generated web-page.\n\nThe attacker would be able to alter the returned web page by simply providing modified data in the user input _POST, which is read by the $PageLoad method at line 10 of /insecure.php. This input then flows through the code straight to the output web page, without sanitization. \r\n\r\nThis can enable a Reflected Cross-Site Scripting (XSS) attack.\n\n",
-						"descriptionHTML": "\u003cp\u003eThe method $PageLoad embeds untrusted data in generated output with echo, at line 11 of /insecure.php. This untrusted data is embedded into the output without proper sanitization or encoding, enabling an attacker to inject malicious code into the generated web-page.\u003c/p\u003e\n\n\u003cp\u003eThe attacker would be able to alter the returned web page by simply providing modified data in the user input _POST, which is read by the $PageLoad method at line 10 of /insecure.php. This input then flows through the code straight to the output web page, without sanitization. \r\n\r\nThis can enable a Reflected Cross-Site Scripting (XSS) attack.\u003c/p\u003e\n",
-						"data": {
-							// eslint-disable-next-line @typescript-eslint/no-loss-of-precision
-							"queryId": 5157925289005576664,
-							"queryName": "Reflected_XSS_All_Clients",
-							"group": "PHP_High_Risk",
-							"resultHash": "ZGJRP6tLG66K4GwKarVTE8GDL/M=",
-							"languageName": "PHP",
-							"nodes": [
-								{
-									"id": "6BkcV9Pylb1Kk14z/xZHkWcP9hk=",
-									"line": 10,
-									"name": "_POST",
-									"column": 8,
-									"length": 6,
-									"method": "$PageLoad",
-									"nodeID": 164,
-									"domType": "UnknownReference",
-									"fileName": "/insecure.php",
-									"fullName": "$NS_insecure_a3ce4a23.$Cls_insecure_a3ce4a23._POST",
-									"typeName": "CxDefaultObject",
-									"methodLine": 1,
-									"definitions": "1"
-								},
-								{
-									"id": "o8XLDcRzoLEzVVdI3yyHchg/JH0=",
-									"line": 10,
-									"name": "var",
-									"column": 1,
-									"length": 4,
-									"method": "$PageLoad",
-									"nodeID": 168,
-									"domType": "UnknownReference",
-									"fileName": "/insecure.php",
-									"fullName": "$NS_insecure_a3ce4a23.$Cls_insecure_a3ce4a23.var",
-									"typeName": "CxDefaultObject",
-									"methodLine": 1,
-									"definitions": "1"
-								},
-								{
-									"id": "yis1SnpLBtDSuxZBPhw76TaDjY4=",
-									"line": 11,
-									"name": "var",
-									"column": 12,
-									"length": 4,
-									"method": "$PageLoad",
-									"nodeID": 184,
-									"domType": "UnknownReference",
-									"fileName": "/insecure.php",
-									"fullName": "$NS_insecure_a3ce4a23.$Cls_insecure_a3ce4a23.var",
-									"typeName": "CxDefaultObject",
-									"methodLine": 1,
-									"definitions": "1"
-								},
-								{
-									"id": "kZuPO2VpUX+yVNtYvSP3FVHVJBQ=",
-									"line": 11,
-									"name": "$_DoubleQuotedString",
-									"column": 0,
-									"length": 20,
-									"method": "$PageLoad",
-									"nodeID": 177,
-									"domType": "MethodInvokeExpr",
-									"fileName": "/insecure.php",
-									"fullName": "$_DoubleQuotedString",
-									"typeName": "$_DoubleQuotedString",
-									"methodLine": 1,
-									"definitions": "0"
-								},
-								{
-									"id": "fO7BgAMUgzMTXcmTFe9v8TGpYPg=",
-									"line": 11,
-									"name": "echo",
-									"column": 1,
-									"length": 4,
-									"method": "$PageLoad",
-									"nodeID": 171,
-									"domType": "MethodInvokeExpr",
-									"fileName": "/insecure.php",
-									"fullName": "echo",
-									"typeName": "echo",
-									"methodLine": 1,
-									"definitions": "0"
-								}
-							]
-						},
-						"comments": {},
-						"vulnerabilityDetails": {
-							"cweId": 79,
-							"cvss": {},
-							"compliances": [
-								"PCI DSS v3.2.1",
-								"ASD STIG 4.10",
-								"FISMA 2014",
-								"NIST SP 800-53",
-								"OWASP Top 10 2013",
-								"OWASP Top 10 2017",
-								"OWASP Top 10 2021"
-							]
-						}
-					},
-					{
-						"type": "sca",
-						"scaType": "Vulnerability",
-						"label": "sca",
-						"id": "cve-2011-3374",
-						"similarityId": "cve-2011-3374",
-						"status": "RECURRENT",
-						"state": "TO_VERIFY",
-						"severity": "LOW",
-						"created": "2023-04-21T10:34:40Z",
-						"firstFoundAt": "2023-02-23T12:19:31Z",
-						"foundAt": "2023-04-21T10:34:40Z",
-						"firstScanId": "eaa0f3ea-ce32-4059-9836-db13d16fb2c8",
-						"description": "It was found that apt-key in apt, all versions, do not correctly validate gpg keys with the master keyring, leading to a potential man-in-the-middle attack.",
-						"descriptionHTML": "\u003cp\u003eIt was found that apt-key in apt, all versions, do not correctly validate gpg keys with the master keyring, leading to a potential man-in-the-middle attack.\u003c/p\u003e\n",
-						"data": {},
-						"comments": {},
-						"vulnerabilityDetails": {
-							"cweId": "CWE-347",
-							"cvssScore": 3.7,
-							"cvss": {
-								"version": 3,
-								"attackVector": "NETWORK",
-								"availability": "NONE",
-								"confidentiality": "NONE",
-								"attackComplexity": "HIGH"
-							}
-						}
-					}
-				]
-			};
-		}
-		writeFileSync(getFilePath() + "/ast-results.json", JSON.stringify(results), {
-			flag: 'w+',
-		});
-	}
+  async getProject(projectId: string): Promise<CxProject | undefined> {
+    if (projectId === "EmptyResultsProjectId") {
+      return {
+        tags: {},
+        groups: [],
+        id: "EmptyResultsProjectId",
+        name: "EmptyResultsProjectName",
+        createdAt: "2023-04-19T09:07:36.846145Z",
+        updatedAt: "2023-04-19T09:07:36.846145Z",
+      };
+    }
+    return {
+      tags: {},
+      groups: [],
+      id: "1",
+      name: "test-proj-21",
+      createdAt: "2023-04-19T09:07:36.846145Z",
+      updatedAt: "2023-04-19T09:07:36.846145Z",
+    };
+  }
 
-	async getScan(scanId: string): Promise<CxScan | undefined> {
+  async getProjectList(): Promise<CxProject[] | undefined> {
+    return [
+      {
+        tags: {
+          integration: "",
+        },
+        groups: ["1"],
+        id: "1",
+        name: "test-proj-21",
+        createdAt: "2023-04-19T14:06:42.186311Z",
+        updatedAt: "2023-04-19T14:26:26.142592Z",
+      },
+      {
+        tags: {},
+        groups: [],
+        id: "2",
+        name: "test-proj-2",
+        createdAt: "2023-04-19T14:15:15.250732Z",
+        updatedAt: "2023-04-19T14:15:15.250732Z",
+      },
+    ];
+  }
 
-		if (scanId === (EMPTY_RESULTS_SCAN_ID)) {
-			return {
-				tags: {
-				},
-				groups: undefined,
-				id: EMPTY_RESULTS_SCAN_ID,
-				projectID: "EmptyResultsProjectId",
-				status: "Completed",
-				createdAt: "2023-03-19T15:10:38.749899+01:00",
-				updatedAt: "2023-03-19T14:11:42.892326Z",
-				origin: "grpc-java-netty 1.35.0",
-				initiator: "tester",
-				branch: "main",
-			};
-		}
-		return {
-			tags: {
-			},
-			groups: undefined,
-			id: "1",
-			projectID: "2588deba-1751-4afc-b7e3-db71727a1edd",
-			status: "Completed",
-			createdAt: "2023-04-19T10:07:37.628413+01:00",
-			updatedAt: "2023-04-19T09:08:27.151913Z",
-			origin: "grpc-java-netty 1.35.0",
-			initiator: "tiago",
-			branch: "main",
-		};
-	}
+  async getBranches(): Promise<string[] | undefined> {
+    return ["main"];
+  }
 
-	async getProject(projectId: string): Promise<CxProject | undefined> {
+  async getScans(): Promise<CxScan[] | undefined> {
+    return [
+      {
+        tags: {},
+        groups: undefined,
+        id: "1",
+        projectID: "test-proj-21",
+        status: "Completed",
+        createdAt: "2023-04-19T15:10:38.749899+01:00",
+        updatedAt: "2023-04-19T14:11:42.892326Z",
+        origin: "grpc-java-netty 1.35.0",
+        initiator: "tester",
+        branch: "main",
+      },
+      {
+        tags: {},
+        groups: undefined,
+        id: "2",
+        projectID: "1",
+        status: "Completed",
+        createdAt: "2023-03-19T15:10:38.749899+01:00",
+        updatedAt: "2023-03-19T14:11:42.892326Z",
+        origin: "grpc-java-netty 1.35.0",
+        initiator: "tester",
+        branch: "main",
+      },
+    ];
+  }
 
-		if (projectId === "EmptyResultsProjectId") {
-			return {
-				tags: {
-				},
-				groups: [
-				],
-				id: "EmptyResultsProjectId",
-				name: "EmptyResultsProjectName",
-				createdAt: "2023-04-19T09:07:36.846145Z",
-				updatedAt: "2023-04-19T09:07:36.846145Z",
-			};
-		}
-		return {
-			tags: {
-			},
-			groups: [
-			],
-			id: "1",
-			name: "test-proj-21",
-			createdAt: "2023-04-19T09:07:36.846145Z",
-			updatedAt: "2023-04-19T09:07:36.846145Z",
-		};
-	}
+  getBaseAstConfiguration() {
+    const config = new CxConfig();
+    config.additionalParameters = vscode.workspace
+      .getConfiguration("checkmarxOne")
+      .get("additionalParams") as string;
 
-	async getProjectList(): Promise<CxProject[] | undefined> {
-		return [
-			{
-				tags: {
-					integration: "",
-				},
-				groups: [
-					"1",
-				],
-				id: "1",
-				name: "test-proj-21",
-				createdAt: "2023-04-19T14:06:42.186311Z",
-				updatedAt: "2023-04-19T14:26:26.142592Z",
-			},
-			{
-				tags: {
-				},
-				groups: [
-				],
-				id: "2",
-				name: "test-proj-2",
-				createdAt: "2023-04-19T14:15:15.250732Z",
-				updatedAt: "2023-04-19T14:15:15.250732Z",
-			},
-		];
-	}
+    return config;
+  }
 
-	async getBranches(): Promise<string[] | undefined> {
-		return ["main"];
-	}
+  getAstConfiguration() {
+    const token = vscode.workspace
+      .getConfiguration("checkmarxOne")
+      .get("apiKey") as string;
+    if (!token) {
+      return undefined;
+    }
 
-	async getScans(): Promise<CxScan[] | undefined> {
-		return [{
-			tags: {
-			},
-			groups: undefined,
-			id: "1",
-			projectID: "test-proj-21",
-			status: "Completed",
-			createdAt: "2023-04-19T15:10:38.749899+01:00",
-			updatedAt: "2023-04-19T14:11:42.892326Z",
-			origin: "grpc-java-netty 1.35.0",
-			initiator: "tester",
-			branch: "main",
-		},
-		{
-			tags: {
-			},
-			groups: undefined,
-			id: "2",
-			projectID: "1",
-			status: "Completed",
-			createdAt: "2023-03-19T15:10:38.749899+01:00",
-			updatedAt: "2023-03-19T14:11:42.892326Z",
-			origin: "grpc-java-netty 1.35.0",
-			initiator: "tester",
-			branch: "main",
-		}];
-	}
+    const config = this.getBaseAstConfiguration();
+    config.apiKey = token;
+    return config;
+  }
 
-	getBaseAstConfiguration() {
-		const config = new CxConfig();
-		config.additionalParameters = vscode.workspace.getConfiguration("checkmarxOne").get("additionalParams") as string;
+  async isScanEnabled(): Promise<boolean> {
+    return true;
+  }
+  async isAIGuidedRemediationEnabled(): Promise<boolean> {
+    return true;
+  }
 
-		return config;
-	}
+  async isSCAScanEnabled(): Promise<boolean> {
+    return true;
+  }
 
+  async triageShow() {
+    return [];
+  }
 
-	getAstConfiguration() {
-		const token = vscode.workspace.getConfiguration("checkmarxOne").get("apiKey") as string;
-		if (!token) {
-			return undefined;
-		}
+  async triageUpdate(): Promise<number> {
+    return 0;
+  }
 
-		const config = this.getBaseAstConfiguration();
-		config.apiKey = token;
-		return config;
-	}
+  async getCodeBashing(): Promise<CxCodeBashing | undefined> {
+    return {
+      path: "https://codebashing.checkmarx.com/courses/java/lessons/sql_injection",
+      cweId: "CWE-89",
+      language: "Java",
+      queryName: "SQL_Injection",
+    };
+  }
 
-	async isScanEnabled(): Promise<boolean> {
-		return true;
-	}
-	async isAIGuidedRemediationEnabled(): Promise<boolean> {
-		return true;
-	}
+  async getResultsBfl() {
+    return "";
+  }
 
-	async isSCAScanEnabled(): Promise<boolean> {
-		return true;
-	}
+  async getResultsRealtime() {
+    return undefined; // does not matter for testing purposes
+  }
 
-	async triageShow() {
-		return [];
-	}
+  async scaRemediation() {
+    return 0;
+  }
 
-	async triageUpdate(): Promise<number> {
-		return 0;
-	}
+  async kicsRemediation() {
+    return undefined; // does not matter for testing purposes
+  }
 
-	async getCodeBashing(): Promise<CxCodeBashing | undefined> {
-		return {
-			path: "https://codebashing.checkmarx.com/courses/java/lessons/sql_injection",
-			cweId: "CWE-89",
-			language: "Java",
-			queryName: "SQL_Injection",
-		};
-	}
+  async learnMore() {
+    return [
+      {
+        queryId: "5157925289005576664",
+        queryName: "Reflected_XSS_All_Clients",
+        queryDescriptionId: "Reflected_XSS_All_Clients",
+        resultDescription:
+          "The method @DestinationMethod embeds untrusted data in generated output with @DestinationElement, at line @DestinationLine of @DestinationFile. This untrusted data is embedded into the output without proper sanitization or encoding, enabling an attacker to inject malicious code into the generated web-page.\n\nThe attacker would be able to alter the returned web page by simply providing modified data in the user input @SourceElement, which is read by the @SourceMethod method at line @SourceLine of @SourceFile. This input then flows through the code straight to the output web page, without sanitization. \r\n\r\nThis can enable a Reflected Cross-Site Scripting (XSS) attack.\n\n",
+        risk: "A successful XSS exploit would allow an attacker to rewrite web pages and insert malicious scripts which would alter the intended output. This could include HTML fragments, CSS styling rules, arbitrary JavaScript, or references to third party code. An attacker could use this to steal users' passwords, collect personal data such as credit card details, provide false information, or run malware. From the victim’s point of view, this is performed by the genuine website, and the victim would blame the site for incurred damage.\n\nThe attacker could use social engineering to cause the user to send the website modified input, which will be returned in the requested web page.\n\n",
+        cause:
+          "The application creates web pages that include untrusted data, whether from user input, the application’s database, or from other external sources. The untrusted data is embedded directly in the page's HTML, causing the browser to display it as part of the web page. If the input includes HTML fragments or JavaScript, these are displayed too, and the user cannot tell that this is not the intended page. The vulnerability is the result of directly embedding arbitrary data without first encoding it in a format that would prevent the browser from treating it like HTML or code instead of plain text.\n\nNote that an attacker can exploit this vulnerability either by modifying the URL, or by submitting malicious data in the user input or other request fields.\n\n",
+        generalRecommendations:
+          '*   Fully encode all dynamic data, regardless of source, before embedding it in output.\r\n*   Encoding should be context-sensitive. For example:\r\n    *   HTML encoding for HTML content\r\n    *   HTML Attribute encoding for data output to attribute values\r\n    *   JavaScript encoding for server-generated JavaScript\r\n*   It is recommended to use the platform-provided encoding functionality, or known security libraries for encoding output.\r\n*   Implement a Content Security Policy (CSP) with explicit whitelists for the application\'s resources only. \r\n*   As an extra layer of protection, validate all untrusted data, regardless of source (note this is not a replacement for encoding). Validation should be based on a whitelist: accept only data fitting a specified structure, rather than reject bad patterns. Check for:\r\n    *   Data type\r\n    *   Size\r\n    *   Range\r\n    *   Format\r\n    *   Expected values\r\n*   In the `Content-Type` HTTP response header, explicitly define character encoding (charset) for the entire page. \r\n*   Set the `HTTPOnly` flag on the session cookie for "Defense in Depth", to prevent any successful XSS exploits from stealing the cookie.\n*   Consider that many native PHP methods for sanitizing values, such as htmlspecialchars and htmlentities, do not inherently encode values for Javascript contexts and ignore certain enclosure characters such as apostrophe (\'), quotes (") and backticks (\\`). Always consider the output context of inputs before choosing either of these functions as sanitizers.',
+        samples: [
+          {
+            progLanguage: "PHP",
+            code: "if (isset($_GET['name'])) {\n    echo \"<h1>Welcome,\" . $_GET['name'] . \"!</h1>\";\n}",
+            title: "Outputting Unsanitized Inputs into HTML Results in XSS",
+          },
+          {
+            progLanguage: "PHP",
+            code: 'if (isset($_GET[\'name\'])) {\n      //The payload "name=\'; alert(1); //" will result in XSS, as "htmlspecialchars" does not sanitize apostrophes\n    echo "<script> var name = \'" . htmlspecialchars($_GET[\'name\']) . "\';</script>\\r\\n"; \n}',
+            title: 'Insecure Use of "htmlspecialchars" Without a Secure Flag\n',
+          },
+          {
+            progLanguage: "PHP",
+            code: 'if (isset($_GET[\'name\'])) {\n    //The payload "name=`; alert(1); //" will result in XSS, as "htmlspecialchars", even in this mode, does not sanitize backticks\n    //ENT_QUOTES flag encodes "&<>\'\n    echo "<script> var name = `" . htmlspecialchars($_GET[\'name\'], ENT_QUOTES, \'UTF-8\') . "`;</script>";\n}',
+            title: 'Insecure Use of "htmlspecialchars" With "ENT_QUOTES" Flag ',
+          },
+          {
+            progLanguage: "PHP",
+            code: "if (isset($_GET['name'])) {\n    //ENT_QUOTES flag sanitizes apostrophe\n    echo \"<script> var name = '\" . htmlspecialchars($_GET['name'], ENT_QUOTES, 'UTF-8') . \"';</script>\";\n}",
+            title: 'Secure Use of "htmlspecialchars" With "ENT_QUOTES" Flag',
+          },
+          {
+            progLanguage: "PHP",
+            code: "if (isset($_GET['name'])) {\n    //ENT_COMPAT flag encodes \"&<>\n    //The payload \"name='; alert(1); //\" will result in XSS, as \"htmlspecialchars\", even in this mode, does not sanitize apostrophe\n    echo \"<script> var name = '\" . htmlspecialchars($_GET['name'], ENT_COMPAT, 'UTF-8') . \"';</script>\";\n}\n",
+            title: 'Insecure Use of "htmlspecialchars" With "ENT_COMPAT" Flag',
+          },
+          {
+            progLanguage: "PHP",
+            code: "if (isset($_GET['name'])) {\n    //ENT_COMPAT flag sanitize quotation marks\n    echo \"<script> var name = \\\"\" . htmlspecialchars($_GET['name'], ENT_COMPAT, 'UTF-8') . \"\\\";</script>\";\n}",
+            title: 'Secure Use of "htmlspecialchars" With "ENT_COMPAT" Flag',
+          },
+        ],
+      },
+    ];
+  }
 
-	async getResultsBfl() {
-		return "";
-	}
+  async runSastGpt() {
+    await this.sleep(1000);
+    return [
+      { conversationId: "0", response: ["Mock message response from gpt"] },
+    ];
+  }
 
-	async getResultsRealtime() {
-		return undefined; // does not matter for testing purposes
+  async runGpt() {
+    await this.sleep(1000);
+    return [
+      { conversationId: "0", response: ["Mock message response from gpt"] },
+    ];
+  }
 
-	}
+  async mask() {
+    await this.sleep(1000);
+    return [
+      { conversationId: "0", response: ["Mock message response from gpt"] },
+    ];
+  }
 
-	async scaRemediation() {
-		return 0;
-	}
+  sleep(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
 
-	async kicsRemediation() {
-		return undefined; // does not matter for testing purposes
-	}
+  updateStatusBarItem(
+    text: string,
+    show: boolean,
+    statusBarItem: vscode.StatusBarItem
+  ) {
+    statusBarItem.text = text;
+    show ? statusBarItem.show() : statusBarItem.hide();
+  }
 
-	async learnMore() {
-		return [{
-			queryId: "5157925289005576664",
-			queryName: "Reflected_XSS_All_Clients",
-			queryDescriptionId: "Reflected_XSS_All_Clients",
-			resultDescription: "The method @DestinationMethod embeds untrusted data in generated output with @DestinationElement, at line @DestinationLine of @DestinationFile. This untrusted data is embedded into the output without proper sanitization or encoding, enabling an attacker to inject malicious code into the generated web-page.\n\nThe attacker would be able to alter the returned web page by simply providing modified data in the user input @SourceElement, which is read by the @SourceMethod method at line @SourceLine of @SourceFile. This input then flows through the code straight to the output web page, without sanitization. \r\n\r\nThis can enable a Reflected Cross-Site Scripting (XSS) attack.\n\n",
-			risk: "A successful XSS exploit would allow an attacker to rewrite web pages and insert malicious scripts which would alter the intended output. This could include HTML fragments, CSS styling rules, arbitrary JavaScript, or references to third party code. An attacker could use this to steal users' passwords, collect personal data such as credit card details, provide false information, or run malware. From the victim’s point of view, this is performed by the genuine website, and the victim would blame the site for incurred damage.\n\nThe attacker could use social engineering to cause the user to send the website modified input, which will be returned in the requested web page.\n\n",
-			cause: "The application creates web pages that include untrusted data, whether from user input, the application’s database, or from other external sources. The untrusted data is embedded directly in the page's HTML, causing the browser to display it as part of the web page. If the input includes HTML fragments or JavaScript, these are displayed too, and the user cannot tell that this is not the intended page. The vulnerability is the result of directly embedding arbitrary data without first encoding it in a format that would prevent the browser from treating it like HTML or code instead of plain text.\n\nNote that an attacker can exploit this vulnerability either by modifying the URL, or by submitting malicious data in the user input or other request fields.\n\n",
-			generalRecommendations: "*   Fully encode all dynamic data, regardless of source, before embedding it in output.\r\n*   Encoding should be context-sensitive. For example:\r\n    *   HTML encoding for HTML content\r\n    *   HTML Attribute encoding for data output to attribute values\r\n    *   JavaScript encoding for server-generated JavaScript\r\n*   It is recommended to use the platform-provided encoding functionality, or known security libraries for encoding output.\r\n*   Implement a Content Security Policy (CSP) with explicit whitelists for the application's resources only. \r\n*   As an extra layer of protection, validate all untrusted data, regardless of source (note this is not a replacement for encoding). Validation should be based on a whitelist: accept only data fitting a specified structure, rather than reject bad patterns. Check for:\r\n    *   Data type\r\n    *   Size\r\n    *   Range\r\n    *   Format\r\n    *   Expected values\r\n*   In the `Content-Type` HTTP response header, explicitly define character encoding (charset) for the entire page. \r\n*   Set the `HTTPOnly` flag on the session cookie for \"Defense in Depth\", to prevent any successful XSS exploits from stealing the cookie.\n*   Consider that many native PHP methods for sanitizing values, such as htmlspecialchars and htmlentities, do not inherently encode values for Javascript contexts and ignore certain enclosure characters such as apostrophe ('), quotes (\") and backticks (\\`). Always consider the output context of inputs before choosing either of these functions as sanitizers.",
-			samples: [
-				{
-					progLanguage: "PHP",
-					code: "if (isset($_GET['name'])) {\n    echo \"<h1>Welcome,\" . $_GET['name'] . \"!</h1>\";\n}",
-					title: "Outputting Unsanitized Inputs into HTML Results in XSS",
-				},
-				{
-					progLanguage: "PHP",
-					code: "if (isset($_GET['name'])) {\n      //The payload \"name='; alert(1); //\" will result in XSS, as \"htmlspecialchars\" does not sanitize apostrophes\n    echo \"<script> var name = '\" . htmlspecialchars($_GET['name']) . \"';</script>\\r\\n\"; \n}",
-					title: "Insecure Use of \"htmlspecialchars\" Without a Secure Flag\n",
-				},
-				{
-					progLanguage: "PHP",
-					code: "if (isset($_GET['name'])) {\n    //The payload \"name=`; alert(1); //\" will result in XSS, as \"htmlspecialchars\", even in this mode, does not sanitize backticks\n    //ENT_QUOTES flag encodes \"&<>'\n    echo \"<script> var name = `\" . htmlspecialchars($_GET['name'], ENT_QUOTES, 'UTF-8') . \"`;</script>\";\n}",
-					title: "Insecure Use of \"htmlspecialchars\" With \"ENT_QUOTES\" Flag ",
-				},
-				{
-					progLanguage: "PHP",
-					code: "if (isset($_GET['name'])) {\n    //ENT_QUOTES flag sanitizes apostrophe\n    echo \"<script> var name = '\" . htmlspecialchars($_GET['name'], ENT_QUOTES, 'UTF-8') . \"';</script>\";\n}",
-					title: "Secure Use of \"htmlspecialchars\" With \"ENT_QUOTES\" Flag",
-				},
-				{
-					progLanguage: "PHP",
-					code: "if (isset($_GET['name'])) {\n    //ENT_COMPAT flag encodes \"&<>\n    //The payload \"name='; alert(1); //\" will result in XSS, as \"htmlspecialchars\", even in this mode, does not sanitize apostrophe\n    echo \"<script> var name = '\" . htmlspecialchars($_GET['name'], ENT_COMPAT, 'UTF-8') . \"';</script>\";\n}\n",
-					title: "Insecure Use of \"htmlspecialchars\" With \"ENT_COMPAT\" Flag",
-				},
-				{
-					progLanguage: "PHP",
-					code: "if (isset($_GET['name'])) {\n    //ENT_COMPAT flag sanitize quotation marks\n    echo \"<script> var name = \\\"\" . htmlspecialchars($_GET['name'], ENT_COMPAT, 'UTF-8') . \"\\\";</script>\";\n}",
-					title: "Secure Use of \"htmlspecialchars\" With \"ENT_COMPAT\" Flag",
-				},
-			],
-		}];
-	}
+  installVorpal(): Promise<CxVorpal> {
+    return null;
+  }
 
-	async runSastGpt() {
-		await this.sleep(1000);
-		return [{ conversationId: '0', response: ["Mock message response from gpt"] }];
-	}
-
-	async runGpt() {
-		await this.sleep(1000);
-		return [{ conversationId: '0', response: ["Mock message response from gpt"] }];
-	}
-
-	async mask() {
-		await this.sleep(1000);
-		return [{ conversationId: '0', response: ["Mock message response from gpt"] }];
-	}
-
-	sleep(ms) {
-		return new Promise(resolve => setTimeout(resolve, ms));
-	}
-
-	updateStatusBarItem(text: string, show: boolean, statusBarItem: vscode.StatusBarItem) {
-		statusBarItem.text = text;
-		show ? statusBarItem.show() : statusBarItem.hide();
-	}
-
-	installVorpal(): Promise<CxVorpal> {
-		return null;
-	}
-
-	async scanVorpal(sourcePath: string): Promise<CxVorpal> {
-		return new CxVorpal();
-	}
+  async scanVorpal(sourcePath: string): Promise<CxVorpal> {
+    return new CxVorpal();
+  }
 }
-

--- a/src/models/SCSSecretDetectionNode.ts
+++ b/src/models/SCSSecretDetectionNode.ts
@@ -1,0 +1,16 @@
+export class SCSSecretDetectionNode {
+  constructor(
+    public id: string,
+    public type: string,
+    public status: string,
+    public state: string,
+    public severity: string,
+    public created: string,
+    public description: string,
+    public ruleName: string,
+    public fileName: string,
+    public line: number,
+    public ruleDescription: string,
+    public remediationAdditional: string
+  ) {}
+}

--- a/src/models/results.ts
+++ b/src/models/results.ts
@@ -6,7 +6,7 @@ import * as vscode from "vscode";
 import {
   StateLevel,
   SeverityLevel,
-  constants
+  constants,
 } from "../utils/common/constants";
 import { KicsNode } from "./kicsNode";
 import { SastNode } from "./sastNode";
@@ -49,9 +49,11 @@ export class AstResult extends CxResult {
   }
 
   constructor(result?: any) {
-    super(result.scaType ? "sca" : result.type, result.data.queryName
-      ? result.data.queryName
-      : result.id
+    super(
+      result.scaType ? "sca" : result.type,
+      result.data.queryName
+        ? result.data.queryName
+        : result.id
         ? result.id
         : result.vulnerabilityDetails.cveName,
       result.id,
@@ -67,16 +69,17 @@ export class AstResult extends CxResult {
       result.data,
       result.comments,
       result.vulnerabilityDetails,
-      result.descriptionHTML);
+      result.descriptionHTML
+    );
     this.id = result.id;
     this.type = result.scaType ? "sca" : result.type;
-    this.typeLabel = result.label;
+    this.typeLabel = this.determineTypeLabel(result);
     this.scaType = result.scaType;
     this.label = result.data.queryName
       ? result.data.queryName
       : result.id
-        ? result.id
-        : result.vulnerabilityDetails.cveName;
+      ? result.id
+      : result.vulnerabilityDetails.cveName;
     this.severity = result.severity;
     this.status = result.status;
     this.language = result.data.languageName;
@@ -95,11 +98,13 @@ export class AstResult extends CxResult {
         this.fileName && this.fileName.includes("/")
           ? this.fileName.slice(this.fileName.lastIndexOf("/"))
           : "";
-      this.label += ` (${shortFilename.length && shortFilename.length > 0
-        ? shortFilename
-        : this.fileName
-        }${result.data.nodes[0].line > 0 ? ":" + result.data.nodes[0].line : ""
-        })`;
+      this.label += ` (${
+        shortFilename.length && shortFilename.length > 0
+          ? shortFilename
+          : this.fileName
+      }${
+        result.data.nodes[0].line > 0 ? ":" + result.data.nodes[0].line : ""
+      })`;
       this.cweId = result.cweId;
       if (!this.cweId) {
         this.cweId = this.cweId = result.vulnerabilityDetails?.cweId;
@@ -111,6 +116,28 @@ export class AstResult extends CxResult {
     if (result.type === constants.kics) {
       this.kicsNode = result;
     }
+  }
+  determineLanguage(result: any): string | undefined {
+    if (result.data && result.data.languageName) {
+      return result.data.languageName;
+    } else if (result.data && result.data.filename) {
+      const fileName = result.data.filename;
+      const extension = fileName.split(".").pop();
+      if (extension) {
+        return extension;
+      }
+    }
+    return undefined;
+  }
+
+  determineTypeLabel(result: any): string | undefined {
+    if (result.label) {
+      return result.label;
+    }
+    if (result.type === "sscs-secret-detection") {
+      return "scs";
+    }
+    return undefined;
   }
 
   getIcon() {
@@ -184,8 +211,6 @@ export class AstResult extends CxResult {
         return vscode.DiagnosticSeverity.Error;
       case constants.mediumSeverity:
         return vscode.DiagnosticSeverity.Warning;
-      case constants.infoSeverity:
-        return vscode.DiagnosticSeverity.Information;
       case constants.infoSeverity:
         return vscode.DiagnosticSeverity.Information;
     }
@@ -274,7 +299,9 @@ export class AstResult extends CxResult {
               data-fullName="${this.kicsNode?.data.filename}" 
               data-length="${1}"
             >
-              ${this.getShortFilename(this.kicsNode?.data.filename)} [${this.kicsNode?.data.line}:${0}]
+              ${this.getShortFilename(this.kicsNode?.data.filename)} [${
+      this.kicsNode?.data.line
+    }:${0}]
             </a>
           </td>
         </tr>
@@ -403,13 +430,15 @@ export class AstResult extends CxResult {
     this.scaNode.scaPackageData.dependencyPaths.forEach(
       (pathArray: any, indexDependency: number) => {
         if (indexDependency === 0) {
-          html += ` <div class="card-content" style="max-height:134px;overflow:scroll;margin-top:15px" id="locations-table-${indexDependency + 1
-            }">
+          html += ` <div class="card-content" style="max-height:134px;overflow:scroll;margin-top:15px" id="locations-table-${
+            indexDependency + 1
+          }">
         <table class="details-table" style="margin-left:28px;margin-top:15px;width:100%">
           <tbody>`;
         } else {
-          html += ` <div class="card-content" style="display:none;max-height:134px;overflow:scroll;margin-top:15px" id="locations-table-${indexDependency + 1
-            }">
+          html += ` <div class="card-content" style="display:none;max-height:134px;overflow:scroll;margin-top:15px" id="locations-table-${
+            indexDependency + 1
+          }">
         <table class="details-table" style="margin-left:28px;" >
           <tbody>`;
         }
@@ -437,10 +466,11 @@ export class AstResult extends CxResult {
                     >
                       ${location}
                     </a>
-                    ${this.scaNode.recommendedVersion &&
-                    this.scaNode.scaPackageData.supportsQuickFix === true &&
-                    this.scaNode.scaPackageData.dependencyPaths[0][0].name
-                    ? ` <img 
+                    ${
+                      this.scaNode.recommendedVersion &&
+                      this.scaNode.scaPackageData.supportsQuickFix === true &&
+                      this.scaNode.scaPackageData.dependencyPaths[0][0].name
+                        ? ` <img 
                           alt="icon" 
                           class="upgrade-small-icon" 
                           src="${scaUpgrade}"
@@ -448,8 +478,8 @@ export class AstResult extends CxResult {
                           data-package="${this.scaNode.scaPackageData.dependencyPaths[0][0].name}" 
                           data-file="${location}"
                         />`
-                    : ""
-                  }
+                        : ""
+                    }
                     ${index + 1 < path.locations.length ? `&nbsp;| &nbsp;` : ""}
                 `;
               });
@@ -529,7 +559,8 @@ export class AstResult extends CxResult {
               <tbody>`;
         } else {
           html += `<div class="card-content">
-            <table class="package-table" style="display: none;" id="package-table-${index + 1
+            <table class="package-table" style="display: none;" id="package-table-${
+              index + 1
             }">
               <tbody>`;
         }
@@ -570,39 +601,44 @@ export class AstResult extends CxResult {
     <div class="left-content">
       <div class="card" style="border-top: 1px;border-top-style: solid;border-color: rgb(128, 128, 128,0.5) ;">
         <div class="description">
-          ${result.descriptionHTML ? result.descriptionHTML : result.description
-      }
+          ${
+            result.descriptionHTML ? result.descriptionHTML : result.description
+          }
         </div>
-        ${type === "realtime"
-        ? `
+        ${
+          type === "realtime"
+            ? `
         <div class="remediation-links-rows-realtime">
           <img class="remediation-links-rows-image" alt="icon" src="${scaUrl}" />
           <p class="remediation-links-text" id="${result.scaNode.scaPackageData.fixLink}">
             About this vulnerability
           </p>
         </div>`
-        : ""
-      }
+            : ""
+        }
       </div>
-      ${result.scaNode.scaPackageData
-        ? `
+      ${
+        result.scaNode.scaPackageData
+          ? `
       <div class="card">
-      ${!type
+      ${
+        !type
           ? `<p class="header-content">
       Remediation
     </p>`
           : ""
-        }
-    ${!type
-          ? `
+      }
+    ${
+      !type
+        ? `
     <div class="card-content">
         <div class="remediation-container">
           ${result.scaRemediation(result, scaUpgrade, scaUrl, type)}	
         </div>
       </div>
     `
-          : ""
-        }
+        : ""
+    }
     </div>
     <div class="card">
         <div style="display: inline-block;position: relative;">
@@ -610,28 +646,32 @@ export class AstResult extends CxResult {
           ${!type ? "Vulnerable Package Paths" : "Vulnerable Package"}
           </p>
         </div>
-        ${result.scaNode.scaPackageData.dependencyPaths
-          ? `
+        ${
+          result.scaNode.scaPackageData.dependencyPaths
+            ? `
         <div class="package-buttons-container">
           <button 
             class="package-back"
             id="package-back"
             data-current="1" 
-            data-total="${result.scaNode.scaPackageData.dependencyPaths.length
-          }" 
+            data-total="${
+              result.scaNode.scaPackageData.dependencyPaths.length
+            }" 
             data-previous="null"
             disabled
           >
           </button>
-          <p id="package-counter" class="package-counter-numbers">1/${result.scaNode.scaPackageData.dependencyPaths.length
+          <p id="package-counter" class="package-counter-numbers">1/${
+            result.scaNode.scaPackageData.dependencyPaths.length
           }</p>
           <button 
             class="package-next"
             data-current="1" 
-            ${result.scaNode.scaPackageData.dependencyPaths.length === 1
-            ? "disabled"
-            : ""
-          }
+            ${
+              result.scaNode.scaPackageData.dependencyPaths.length === 1
+                ? "disabled"
+                : ""
+            }
             data-total="${result.scaNode.scaPackageData.dependencyPaths.length}"
             id="package-next"
             data-previous="null"
@@ -640,7 +680,7 @@ export class AstResult extends CxResult {
         </div>
       ${result.scaPackages(scaUpgrade)}	
     </div>`
-          : !type
+            : !type
             ? `
           <div class="card-content">
             <p style="margin:25px;font-size:0.9em">
@@ -666,7 +706,7 @@ export class AstResult extends CxResult {
     </div>
   </div>
       `
-        : `
+          : `
     <div class="card" style="border:0">
       <p style="margin:25px;font-size:0.9em"> 
         No more information available
@@ -676,8 +716,9 @@ export class AstResult extends CxResult {
     `
       }
   <div class="right-content">
-    ${result.vulnerabilityDetails.cvss &&
-        result.vulnerabilityDetails.cvss.version
+    ${
+      result.vulnerabilityDetails.cvss &&
+      result.vulnerabilityDetails.cvss.version
         ? `
       <div class="content">
         <div class="header-content-selected">
@@ -696,22 +737,28 @@ export class AstResult extends CxResult {
         </div>
       </div>
     `
-      }
+    }
     <div class="sca-details" style="border-bottom: 1px;border-bottom-style: solid;border-color: rgb(128, 128, 128,0.5);">
-      <div class="score-card" style="${result.severity === "HIGH"
-        ? "border: 1px solid #D94B48"
-        : result.severity === "MEDIUM"
+      <div class="score-card" style="${
+        result.severity === "HIGH"
+          ? "border: 1px solid #D94B48"
+          : result.severity === "MEDIUM"
           ? "border: 1px solid #F9AE4D"
           : result.severity === "LOW"
-            ? "border: 1px solid #029302"
-            : "border: 1px solid #87bed1"
+          ? "border: 1px solid #029302"
+          : "border: 1px solid #87bed1"
       }">
         <div class="left-${result.severity}">
           <p class="header-text">
             Score
           </p>
           <p>
-              ${result.vulnerabilityDetails && result.vulnerabilityDetails.cvssScore ? result.vulnerabilityDetails.cvssScore.toFixed(1) : 'N/A'}
+              ${
+                result.vulnerabilityDetails &&
+                result.vulnerabilityDetails.cvssScore
+                  ? result.vulnerabilityDetails.cvssScore.toFixed(1)
+                  : "N/A"
+              }
           </p>
         </div>
         <div class="right-${result.severity}">
@@ -732,11 +779,12 @@ export class AstResult extends CxResult {
             Attack Vector
           </p>
           <p class="info-cards-value">
-            ${result.vulnerabilityDetails.cvss &&
-        result.vulnerabilityDetails.cvss.attackVector
-        ? result.vulnerabilityDetails.cvss.attackVector
-        : "No information"
-      }
+            ${
+              result.vulnerabilityDetails.cvss &&
+              result.vulnerabilityDetails.cvss.attackVector
+                ? result.vulnerabilityDetails.cvss.attackVector
+                : "No information"
+            }
           </p>
         </div>
         <div class="info-cards-icon">
@@ -751,11 +799,12 @@ export class AstResult extends CxResult {
             Attack Complexity
           </p>
           <p class="info-cards-value">
-            ${result.vulnerabilityDetails.cvss &&
-        result.vulnerabilityDetails.cvss.attackComplexity
-        ? result.vulnerabilityDetails.cvss.attackComplexity
-        : "No information"
-      }
+            ${
+              result.vulnerabilityDetails.cvss &&
+              result.vulnerabilityDetails.cvss.attackComplexity
+                ? result.vulnerabilityDetails.cvss.attackComplexity
+                : "No information"
+            }
           </p>
         </div>
         <div class="info-cards-icon">
@@ -763,8 +812,9 @@ export class AstResult extends CxResult {
         </div>
       </div>
     </div>
-    ${result.vulnerabilityDetails.cvss &&
-        result.vulnerabilityDetails.cvss.privilegesRequired
+    ${
+      result.vulnerabilityDetails.cvss &&
+      result.vulnerabilityDetails.cvss.privilegesRequired
         ? `
       <div class="sca-details">
       <div class="info-cards">
@@ -773,10 +823,11 @@ export class AstResult extends CxResult {
             Privileges Required
           </p>
           <p class="info-cards-value">
-            ${result.vulnerabilityDetails.cvss.privilegesRequired
-          ? result.vulnerabilityDetails.cvss.privilegesRequired
-          : "No information"
-        }
+            ${
+              result.vulnerabilityDetails.cvss.privilegesRequired
+                ? result.vulnerabilityDetails.cvss.privilegesRequired
+                : "No information"
+            }
           </p>
         </div>
         <div class="info-cards-icon">
@@ -785,7 +836,7 @@ export class AstResult extends CxResult {
       </div>
     </div>`
         : ``
-      }
+    }
     <div class="sca-details">
       <div class="info-cards">
         <div class="info-cards-text">
@@ -793,11 +844,12 @@ export class AstResult extends CxResult {
             Confidentiality Impact
           </p>
           <p class="info-cards-value">
-            ${result.vulnerabilityDetails.cvss &&
-        result.vulnerabilityDetails.cvss.confidentiality
-        ? result.vulnerabilityDetails.cvss.confidentiality
-        : "No information"
-      }
+            ${
+              result.vulnerabilityDetails.cvss &&
+              result.vulnerabilityDetails.cvss.confidentiality
+                ? result.vulnerabilityDetails.cvss.confidentiality
+                : "No information"
+            }
           </p>
         </div>
         <div class="info-cards-icon">
@@ -805,8 +857,9 @@ export class AstResult extends CxResult {
         </div>
       </div>
     </div>
-    ${result.vulnerabilityDetails.cvss &&
-        result.vulnerabilityDetails.cvss.integrityImpact
+    ${
+      result.vulnerabilityDetails.cvss &&
+      result.vulnerabilityDetails.cvss.integrityImpact
         ? `
       <div class="sca-details">
         <div class="info-cards">
@@ -815,10 +868,11 @@ export class AstResult extends CxResult {
               Integrity Impact
             </p>
             <p class="info-cards-value">
-              ${result.vulnerabilityDetails.cvss.integrityImpact
-          ? result.vulnerabilityDetails.cvss.integrityImpact
-          : "No information"
-        }
+              ${
+                result.vulnerabilityDetails.cvss.integrityImpact
+                  ? result.vulnerabilityDetails.cvss.integrityImpact
+                  : "No information"
+              }
             </p>
           </div>
           <div class="info-cards-icon">
@@ -827,7 +881,7 @@ export class AstResult extends CxResult {
         </div>
       </div>`
         : ``
-      }
+    }
     <div class="sca-details">
       <div class="info-cards">
         <div class="info-cards-text">
@@ -835,11 +889,12 @@ export class AstResult extends CxResult {
             Availability Impact
           </p>
           <p class="info-cards-value">
-            ${result.vulnerabilityDetails.cvss &&
-        result.vulnerabilityDetails.cvss.availability
-        ? result.vulnerabilityDetails.cvss.availability
-        : "No information"
-      }
+            ${
+              result.vulnerabilityDetails.cvss &&
+              result.vulnerabilityDetails.cvss.availability
+                ? result.vulnerabilityDetails.cvss.availability
+                : "No information"
+            }
           </p>
         </div>
         <div class="info-cards-icon">
@@ -852,71 +907,83 @@ export class AstResult extends CxResult {
 
   private scaRemediation(result, scaUpgrade, scaUrl, type?) {
     return `
-            ${!type
-        ? `<div 
-              class=${result.scaNode.recommendedVersion &&
-          result.scaNode.scaPackageData.supportsQuickFix === true
-          ? "remediation-icon"
-          : "remediation-icon-disabled"
-        }
-              data-version="${result.scaNode.recommendedVersion &&
-          result.scaNode.scaPackageData.supportsQuickFix === true
-          ? result.scaNode.recommendedVersion
-          : ""
-        }" 
-              data-package="${result.scaNode.scaPackageData.dependencyPaths &&
-          result.scaNode.scaPackageData.dependencyPaths[0][0].name
-          ? result.scaNode.scaPackageData.dependencyPaths[0][0].name
-          : ""
-        }" 
-              data-file="${result.scaNode.scaPackageData.dependencyPaths &&
-          result.scaNode.scaPackageData.dependencyPaths[0][0].locations
-          ? result.scaNode.scaPackageData.dependencyPaths[0][0]
-            .locations
-          : ""
-        }"
+            ${
+              !type
+                ? `<div 
+              class=${
+                result.scaNode.recommendedVersion &&
+                result.scaNode.scaPackageData.supportsQuickFix === true
+                  ? "remediation-icon"
+                  : "remediation-icon-disabled"
+              }
+              data-version="${
+                result.scaNode.recommendedVersion &&
+                result.scaNode.scaPackageData.supportsQuickFix === true
+                  ? result.scaNode.recommendedVersion
+                  : ""
+              }" 
+              data-package="${
+                result.scaNode.scaPackageData.dependencyPaths &&
+                result.scaNode.scaPackageData.dependencyPaths[0][0].name
+                  ? result.scaNode.scaPackageData.dependencyPaths[0][0].name
+                  : ""
+              }" 
+              data-file="${
+                result.scaNode.scaPackageData.dependencyPaths &&
+                result.scaNode.scaPackageData.dependencyPaths[0][0].locations
+                  ? result.scaNode.scaPackageData.dependencyPaths[0][0]
+                      .locations
+                  : ""
+              }"
               >
                 <img 
-                  data-version="${result.scaNode.recommendedVersion
-          ? result.scaNode.recommendedVersion
-          : ""
-        }" 
-                  data-package="${result.scaNode.scaPackageData.dependencyPaths &&
-          result.scaNode.scaPackageData.dependencyPaths[0][0].name
-          ? result.scaNode.scaPackageData.dependencyPaths[0][0].name
-          : ""
-        }" 
-                  data-file="${result.scaNode.scaPackageData.dependencyPaths &&
-          result.scaNode.scaPackageData.dependencyPaths[0][0]
-            .locations
-          ? result.scaNode.scaPackageData.dependencyPaths[0][0]
-            .locations
-          : ""
-        }" 
+                  data-version="${
+                    result.scaNode.recommendedVersion
+                      ? result.scaNode.recommendedVersion
+                      : ""
+                  }" 
+                  data-package="${
+                    result.scaNode.scaPackageData.dependencyPaths &&
+                    result.scaNode.scaPackageData.dependencyPaths[0][0].name
+                      ? result.scaNode.scaPackageData.dependencyPaths[0][0].name
+                      : ""
+                  }" 
+                  data-file="${
+                    result.scaNode.scaPackageData.dependencyPaths &&
+                    result.scaNode.scaPackageData.dependencyPaths[0][0]
+                      .locations
+                      ? result.scaNode.scaPackageData.dependencyPaths[0][0]
+                          .locations
+                      : ""
+                  }" 
                   alt="icon" src="${scaUpgrade}" 
                   class="remediation-upgrade" />
               </div>
             <div 
-            class=${result.scaNode.recommendedVersion &&
-          result.scaNode.scaPackageData.supportsQuickFix === true
-          ? "remediation-version"
-          : "remediation-version-disabled"
-        }
-            data-version="${result.scaNode.recommendedVersion &&
-          result.scaNode.scaPackageData.supportsQuickFix === true
-          ? result.scaNode.recommendedVersion
-          : ""
-        }" 
-            data-package="${result.scaNode.scaPackageData.dependencyPaths &&
-          result.scaNode.scaPackageData.dependencyPaths[0][0].name
-          ? result.scaNode.scaPackageData.dependencyPaths[0][0].name
-          : ""
-        }" 
-            data-file="${result.scaNode.scaPackageData.dependencyPaths &&
-          result.scaNode.scaPackageData.dependencyPaths[0][0].locations
-          ? result.scaNode.scaPackageData.dependencyPaths[0][0].locations
-          : ""
-        }"
+            class=${
+              result.scaNode.recommendedVersion &&
+              result.scaNode.scaPackageData.supportsQuickFix === true
+                ? "remediation-version"
+                : "remediation-version-disabled"
+            }
+            data-version="${
+              result.scaNode.recommendedVersion &&
+              result.scaNode.scaPackageData.supportsQuickFix === true
+                ? result.scaNode.recommendedVersion
+                : ""
+            }" 
+            data-package="${
+              result.scaNode.scaPackageData.dependencyPaths &&
+              result.scaNode.scaPackageData.dependencyPaths[0][0].name
+                ? result.scaNode.scaPackageData.dependencyPaths[0][0].name
+                : ""
+            }" 
+            data-file="${
+              result.scaNode.scaPackageData.dependencyPaths &&
+              result.scaNode.scaPackageData.dependencyPaths[0][0].locations
+                ? result.scaNode.scaPackageData.dependencyPaths[0][0].locations
+                : ""
+            }"
             >
             
               <div class="remediation-version-container">
@@ -924,30 +991,35 @@ export class AstResult extends CxResult {
                   Upgrade To Version
                 </p>
                 <p
-                  class=${result.scaNode.recommendedVersion &&
-          result.scaNode.scaPackageData.supportsQuickFix === true
-          ? "version"
-          : "version-disabled"
-        }
-                  data-version="${result.scaNode.recommendedVersion
-          ? result.scaNode.recommendedVersion
-          : ""
-        }" 
-                data-package="${result.scaNode.scaPackageData.dependencyPaths &&
-          result.scaNode.scaPackageData.dependencyPaths[0][0].name
-          ? result.scaNode.scaPackageData.dependencyPaths[0][0].name
-          : ""
-        }" 
-                data-file="${result.scaNode.scaPackageData.dependencyPaths &&
-          result.scaNode.scaPackageData.dependencyPaths[0][0].locations
-          ? result.scaNode.scaPackageData.dependencyPaths[0][0]
-            .locations
-          : ""
-        }">
-                  ${result.scaNode.recommendedVersion
-          ? result.scaNode.recommendedVersion
-          : "Not available"
-        }
+                  class=${
+                    result.scaNode.recommendedVersion &&
+                    result.scaNode.scaPackageData.supportsQuickFix === true
+                      ? "version"
+                      : "version-disabled"
+                  }
+                  data-version="${
+                    result.scaNode.recommendedVersion
+                      ? result.scaNode.recommendedVersion
+                      : ""
+                  }" 
+                data-package="${
+                  result.scaNode.scaPackageData.dependencyPaths &&
+                  result.scaNode.scaPackageData.dependencyPaths[0][0].name
+                    ? result.scaNode.scaPackageData.dependencyPaths[0][0].name
+                    : ""
+                }" 
+                data-file="${
+                  result.scaNode.scaPackageData.dependencyPaths &&
+                  result.scaNode.scaPackageData.dependencyPaths[0][0].locations
+                    ? result.scaNode.scaPackageData.dependencyPaths[0][0]
+                        .locations
+                    : ""
+                }">
+                  ${
+                    result.scaNode.recommendedVersion
+                      ? result.scaNode.recommendedVersion
+                      : "Not available"
+                  }
                 </p>
               </div>
             </div>
@@ -955,23 +1027,24 @@ export class AstResult extends CxResult {
               <div class="remediation-links-about">
                 <div class="remediation-links-rows">
                   <img class="remediation-links-rows-image" alt="icon" src="${scaUrl}" />
-                  ${result.scaNode.scaPackageData.fixLink &&
-          result.scaNode.scaPackageData.fixLink !== ""
-          ? `
+                  ${
+                    result.scaNode.scaPackageData.fixLink &&
+                    result.scaNode.scaPackageData.fixLink !== ""
+                      ? `
                   <p class="remediation-links-text" id="${result.scaNode.scaPackageData.fixLink}">
                     About this vulnerability
                   </p>
                 `
-          : ` <p class="remediation-links-text-disabled" id="${result.scaNode.scaPackageData.fixLink}">
+                      : ` <p class="remediation-links-text-disabled" id="${result.scaNode.scaPackageData.fixLink}">
                       About this vulnerability
                     </p>`
-        }
+                  }
                  
                 </div>
               </div>
             </div>
             `
-        : ``
-      }`;
+                : ``
+            }`;
   }
 }

--- a/src/models/results.ts
+++ b/src/models/results.ts
@@ -126,7 +126,7 @@ export class AstResult extends CxResult {
         result.data.nodes[0].line > 0 ? ":" + result.data.nodes[0].line : ""
       })`;
     } else if (result.data.fileName) {
-      //Relevant for scs , because this engine  have the filename inside result.data
+      //Relevant for scs  , because this engine  have the filename inside result.data
       this.fileName = result.data.fileName;
       const shortFilename =
         this.fileName && this.fileName.includes("/")

--- a/src/models/results.ts
+++ b/src/models/results.ts
@@ -104,7 +104,7 @@ export class AstResult extends CxResult {
     if (result.type === constants.kics) {
       this.kicsNode = result;
     }
-    if (result.type === constants.scs) {
+    if (result.type === constants.scsSecretDetection) {
       this.scsNode = result;
     }
   }
@@ -144,8 +144,8 @@ export class AstResult extends CxResult {
     if (result.label) {
       return result.label;
     }
-    if (result.type === constants.scs) {
-      return "scs";
+    if (result.type === constants.scsSecretDetection) {
+      return constants.scs;
     }
     return undefined;
   }

--- a/src/models/results.ts
+++ b/src/models/results.ts
@@ -110,6 +110,7 @@ export class AstResult extends CxResult {
   }
 
   handleFileNameAndLine(result: any): void {
+    // Relevant for sast, sca , kicks because , they have the filename inside result.data.nodes
     if (result.data.nodes && result.data.nodes[0]) {
       this.sastNodes = result.data.nodes;
       this.fileName = result.data.nodes[0].fileName;
@@ -125,6 +126,7 @@ export class AstResult extends CxResult {
         result.data.nodes[0].line > 0 ? ":" + result.data.nodes[0].line : ""
       })`;
     } else if (result.data.fileName) {
+      //Relevant for scs , because this engine  have the filename inside result.data
       this.fileName = result.data.fileName;
       const shortFilename =
         this.fileName && this.fileName.includes("/")

--- a/src/test/9.scsGroubByFilterWindow.test.ts
+++ b/src/test/9.scsGroubByFilterWindow.test.ts
@@ -1,0 +1,201 @@
+import {
+  By,
+  CustomTreeSection,
+  EditorView,
+  InputBox,
+  VSBrowser,
+  WebDriver,
+  Workbench,
+  BottomBarPanel,
+} from "vscode-extension-tester";
+import { expect } from "chai";
+import {
+  getDetailsView,
+  getResults,
+  initialize,
+  validateRootNode,
+  getQuickPickSelector,
+} from "./utils/utils";
+import {
+  CHANGES_LABEL,
+  CX_LOOK_SCAN,
+  GENERAL_LABEL,
+  LEARN_MORE_LABEL,
+  SCAN_KEY_TREE_LABEL,
+  SCS_Type,
+  CX_GROUP_STATUS,
+  CX_GROUP_STATE,
+  CX_GROUP_FILE,
+  CX_GROUP_SEVERITY,
+  CX_SELECT_PROJECT,
+  PROJECT_KEY_TREE,
+  CX_SELECT_BRANCH,
+  BRANCH_KEY_TREE,
+  CX_SELECT_SCAN,
+  SCAN_KEY_TREE,
+  CX_FILTER_NOT_EXPLOITABLE,
+  CX_FILTER_PROPOSED_NOT_EXPLOITABLE,
+  CX_FILTER_CONFIRMED,
+  CX_FILTER_TO_VERIFY,
+  CX_FILTER_URGENT,
+  CX_FILTER_NOT_IGNORED,
+} from "./utils/constants";
+import { SCAN_ID, CX_TEST_SCAN_PROJECT_NAME } from "./utils/envs";
+
+describe("Get SCS results and checking GroupBy , Filter and Open details window", () => {
+  let bench: Workbench;
+  let treeScans: CustomTreeSection;
+  let driver: WebDriver;
+
+  before(async function () {
+    this.timeout(8000);
+    bench = new Workbench();
+    driver = VSBrowser.instance.driver;
+    const bottomBar = new BottomBarPanel();
+    await bottomBar.toggle(false);
+  });
+
+  after(async () => {
+    await new EditorView().closeAllEditors();
+  });
+
+  it("should select project", async function () {
+    treeScans = await initialize();
+    // Execute project selection command
+    await bench.executeCommand(CX_SELECT_PROJECT);
+    const input = await InputBox.create();
+    await input.setText(CX_TEST_SCAN_PROJECT_NAME);
+    // Select from the pickers list
+    let projectName = await getQuickPickSelector(input);
+    await input.setText(projectName);
+    await input.confirm();
+    // Wait for project selection to be made
+    let project = await treeScans?.findItem(PROJECT_KEY_TREE + projectName);
+    expect(project).is.not.undefined;
+  });
+
+  it("should select branch", async function () {
+    let treeScans = await initialize();
+    // Execute branch selection command
+    await bench.executeCommand(CX_SELECT_BRANCH);
+    let input = await InputBox.create();
+    // Select from the pickers list
+    let branchName = await getQuickPickSelector(input);
+    await input.setText(branchName);
+    await input.confirm();
+    // Wait for branch selection to be made
+    let branch = await treeScans?.findItem(BRANCH_KEY_TREE + branchName);
+    expect(branch).is.not.undefined;
+  });
+
+  it("should select scan", async function () {
+    let treeScans = await initialize();
+    // Execute scan selection command
+    await bench.executeCommand(CX_SELECT_SCAN);
+    let input = await InputBox.create();
+    // Select from the pickers list
+    let scanDate = await getQuickPickSelector(input);
+    await input.setText(scanDate);
+    await input.confirm();
+    // Wait for scan selection to be made
+    const scanDetailsparts: string[] = scanDate.split(" ");
+    const formattedId: string = scanDetailsparts.slice(-2).join(" ");
+    let scan = await treeScans?.findItem(SCAN_KEY_TREE + formattedId);
+    expect(scan).is.not.undefined;
+  });
+
+  it("should load results from scan ID", async function () {
+    await bench.executeCommand(CX_LOOK_SCAN);
+    let input = await new InputBox();
+    await input.setText(SCAN_ID);
+    await input.confirm();
+  });
+
+  it("SCS tree with GroupBy command ", async function () {
+    treeScans = await initialize();
+    while (treeScans === undefined) {
+      treeScans = await initialize();
+    }
+    let scan = await treeScans?.findItem(SCAN_KEY_TREE_LABEL);
+
+    let scsnode = await scan?.findChildItem(SCS_Type);
+    if (scsnode === undefined) {
+      scsnode = await scan?.findChildItem(SCS_Type);
+    }
+    let result = await getResults(scsnode);
+    await result[0].click();
+
+    const commands = [
+      CX_GROUP_FILE,
+      CX_GROUP_SEVERITY,
+      CX_GROUP_STATE,
+      CX_GROUP_STATUS,
+    ];
+
+    let tuple = await validateRootNode(scan);
+
+    for (const command of commands) {
+      await bench.executeCommand(command);
+    }
+
+    expect(tuple[0]).to.be.at.most(4);
+  });
+
+  it("SCS tree with Filter command", async function () {
+    await initialize();
+    const commands = [
+      CX_FILTER_NOT_EXPLOITABLE,
+      CX_FILTER_PROPOSED_NOT_EXPLOITABLE,
+      CX_FILTER_CONFIRMED,
+      CX_FILTER_TO_VERIFY,
+      CX_FILTER_URGENT,
+      CX_FILTER_NOT_IGNORED,
+    ];
+    for (var index in commands) {
+      await bench.executeCommand(commands[index]);
+      expect(index).not.to.be.undefined;
+    }
+  });
+
+  it("should click on General tab", async function () {
+    const detailsView = await getDetailsView();
+    // Find General Tab
+    let generalTab = await detailsView.findWebElement(By.id(GENERAL_LABEL));
+    while (generalTab === undefined) {
+      generalTab = await detailsView.findWebElement(By.id(GENERAL_LABEL));
+    }
+    expect(generalTab).is.not.undefined;
+    await generalTab.click();
+    await detailsView.switchBack();
+  });
+
+  it("should click on Description tab", async function () {
+    // Open details view
+    const detailsView = await getDetailsView();
+    // Find Description Tab
+    let descriptionTab = await detailsView.findWebElement(
+      By.id(LEARN_MORE_LABEL)
+    );
+    while (descriptionTab === undefined) {
+      descriptionTab = await detailsView.findWebElement(
+        By.id(LEARN_MORE_LABEL)
+      );
+    }
+    expect(descriptionTab).is.not.undefined;
+    await descriptionTab.click();
+    await detailsView.switchBack();
+  });
+
+  it("should click on Remediation tab", async function () {
+    // Open details view
+    const detailsView = await getDetailsView();
+    // Find Remediation Tab
+    let remediationTab = await detailsView.findWebElement(By.id(CHANGES_LABEL));
+    while (remediationTab === undefined) {
+      remediationTab = await detailsView.findWebElement(By.id(CHANGES_LABEL));
+    }
+    expect(remediationTab).is.not.undefined;
+    await remediationTab.click();
+    await detailsView.switchBack();
+  });
+});

--- a/src/test/9.scsGroubByFilterWindow.test.ts
+++ b/src/test/9.scsGroubByFilterWindow.test.ts
@@ -15,6 +15,7 @@ import {
   initialize,
   validateRootNode,
   getQuickPickSelector,
+  clickFirstVulnerability,
 } from "./utils/utils";
 import {
   CHANGES_LABEL,
@@ -39,6 +40,9 @@ import {
   CX_FILTER_TO_VERIFY,
   CX_FILTER_URGENT,
   CX_FILTER_NOT_IGNORED,
+  CX_CLEAR,
+  CX_GROUP_LANGUAGE,
+  CX_GROUP_QUERY_NAME,
 } from "./utils/constants";
 import { SCAN_ID, CX_TEST_SCAN_PROJECT_NAME } from "./utils/envs";
 
@@ -51,12 +55,36 @@ describe("Get SCS results and checking GroupBy , Filter and Open details window"
     this.timeout(8000);
     bench = new Workbench();
     driver = VSBrowser.instance.driver;
-    const bottomBar = new BottomBarPanel();
-    await bottomBar.toggle(false);
+    await new Workbench().executeCommand("workbench.action.closeActiveEditor");
+    await bench.executeCommand(CX_CLEAR);
   });
 
   after(async () => {
     await new EditorView().closeAllEditors();
+  });
+
+  it("should clear groub by for scs and open details window ", async function () {
+    const commands = [
+      CX_GROUP_LANGUAGE,
+      CX_GROUP_STATUS,
+      CX_GROUP_STATE,
+      CX_GROUP_QUERY_NAME,
+      CX_GROUP_FILE,
+      CX_FILTER_NOT_EXPLOITABLE,
+      CX_FILTER_PROPOSED_NOT_EXPLOITABLE,
+      CX_FILTER_CONFIRMED,
+      CX_FILTER_TO_VERIFY,
+      CX_FILTER_URGENT,
+      CX_FILTER_NOT_IGNORED,
+      CX_GROUP_FILE,
+      CX_GROUP_STATE,
+      CX_GROUP_STATUS,
+      CX_GROUP_SEVERITY,
+    ];
+
+    for (var index in commands) {
+      await bench.executeCommand(commands[index]);
+    }
   });
 
   it("should select project", async function () {
@@ -122,8 +150,7 @@ describe("Get SCS results and checking GroupBy , Filter and Open details window"
     if (scsnode === undefined) {
       scsnode = await scan?.findChildItem(SCS_Type);
     }
-    let result = await getResults(scsnode);
-    await result[0].click();
+    await clickFirstVulnerability(scsnode);
 
     const commands = [
       CX_GROUP_FILE,

--- a/src/test/utils/constants.ts
+++ b/src/test/utils/constants.ts
@@ -29,7 +29,8 @@ export const CX_FILTER_MEDIUM = "ast-results: Filter severity: Medium";
 export const CX_FILTER_HIGH = "ast-results: Filter severity: High";
 
 export const CX_FILTER_NOT_EXPLOITABLE = "ast-results:Filter: Not Exploitable";
-export const CX_FILTER_PROPOSED_NOT_EXPLOITABLE = "ast-results:Filter: Proposed Not Exploitable";
+export const CX_FILTER_PROPOSED_NOT_EXPLOITABLE =
+  "ast-results:Filter: Proposed Not Exploitable";
 export const CX_FILTER_CONFIRMED = "ast-results:Filter: Confirmed";
 export const CX_FILTER_TO_VERIFY = "ast-results:Filter: To Verify";
 export const CX_FILTER_URGENT = "ast-results:Filter: Urgent";
@@ -49,8 +50,8 @@ export const CX_GROUP_QUERY_NAME = "ast-results: Group by: Vulnerability Type";
 export const CX_CATETORY = "Checkmarx One";
 export const CX_API_KEY_SETTINGS = "Api Key";
 
-export const UUID_REGEX_VALIDATION = /[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}/gi;
-
+export const UUID_REGEX_VALIDATION =
+  /[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}/gi;
 
 export const STEP_1 = "Checkmarx One Scan selection (1/3)";
 export const STEP_2 = "Checkmarx One Scan selection (2/3)";
@@ -62,6 +63,7 @@ export const SCAN_KEY_TREE_LABEL = "Scan";
 export const BRANCH_KEY_TREE = "Branch:  ";
 
 export const SAST_TYPE = "sast";
+export const SCS_Type = "scs";
 
 export const WEBVIEW_TITLE = "cx_title";
 export const CODEBASHING_HEADER = "cx_header_codebashing";

--- a/src/test/utils/utils.ts
+++ b/src/test/utils/utils.ts
@@ -1,98 +1,128 @@
-import { ActivityBar, ViewControl, CustomTreeSection, SideBarView, InputBox, WebView } from 'vscode-extension-tester';
-import { FIVE_SECONDS, THIRTY_SECONDS, THREE_SECONDS } from './constants';
+import {
+  ActivityBar,
+  ViewControl,
+  CustomTreeSection,
+  SideBarView,
+  InputBox,
+  WebView,
+} from "vscode-extension-tester";
+import { FIVE_SECONDS, THIRTY_SECONDS, THREE_SECONDS } from "./constants";
 
 export async function createControl(): Promise<ViewControl | undefined> {
-	const r = await new ActivityBar().getViewControl('Checkmarx');
-	return r;
+  const r = await new ActivityBar().getViewControl("Checkmarx");
+  return r;
 }
 
-export async function createView(control: ViewControl): Promise<SideBarView | undefined> {
-	return await control.openView();
+export async function createView(
+  control: ViewControl
+): Promise<SideBarView | undefined> {
+  return await control.openView();
 }
 
-export async function createTree(view: SideBarView | undefined): Promise<CustomTreeSection | undefined> {
-	return await view?.getContent().getSection("Checkmarx One Results") as CustomTreeSection;
+export async function createTree(
+  view: SideBarView | undefined
+): Promise<CustomTreeSection | undefined> {
+  return (await view
+    ?.getContent()
+    .getSection("Checkmarx One Results")) as CustomTreeSection;
 }
 
 export async function initialize(): Promise<CustomTreeSection | undefined> {
-	const control = await createControl();
-	let view;
-	if (control) {
-		view = await createView(control);
-	}
-	return await createTree(view);
+  const control = await createControl();
+  let view;
+  if (control) {
+    view = await createView(control);
+  }
+  return await createTree(view);
 }
 
 export async function initializeSCA(): Promise<CustomTreeSection | undefined> {
-	const control = await createControl();
-	let view;
-	if (control) {
-		view = await createView(control);
-	}
-	return await createTreeSCA(view);
+  const control = await createControl();
+  let view;
+  if (control) {
+    view = await createView(control);
+  }
+  return await createTreeSCA(view);
 }
 
-export async function createTreeSCA(view: SideBarView | undefined): Promise<CustomTreeSection | undefined> {
-	return await view?.getContent().getSection("Software Composition Analysis (SCA)") as CustomTreeSection;
+export async function createTreeSCA(
+  view: SideBarView | undefined
+): Promise<CustomTreeSection | undefined> {
+  return (await view
+    ?.getContent()
+    .getSection("Software Composition Analysis (SCA)")) as CustomTreeSection;
 }
 
 export async function quickPickSelector(input: InputBox) {
-	await input.selectQuickPick(0);
+  await input.selectQuickPick(0);
 }
 export async function getQuickPickSelector(input: InputBox): Promise<string> {
-	let projectList = await input.getQuickPicks();
-	return await projectList[0].getText();
+  let projectList = await input.getQuickPicks();
+  return await projectList[0].getText();
 }
 
 export async function getResults(scan: any): Promise<any[]> {
-	let children = await scan.getChildren();
-	// Expand the first results
-	await children![0].expand();
-	let type = await children![0].getChildren();
-	return type;
+  let children = await scan.getChildren();
+  // Expand the first results
+  await children![0].expand();
+  let type = await children![0].getChildren();
+  return type;
 }
 
-export async function validateSeverities(scan: any, severity: string): Promise<boolean> {
-	var r = true;
-	let children = await scan.getChildren();
-	children.forEach((element: { getLabel: () => any; }) => {
-		if (element.getLabel() === severity) {
-			r = false;
-		}
-	});
-	return r;
+export async function clickFirstVulnerability(scan: any): Promise<void> {
+  let vulnerabilities = await scan.getChildren();
+
+  if (vulnerabilities.length > 0) {
+    await vulnerabilities[0].click();
+  }
+}
+
+export async function validateSeverities(
+  scan: any,
+  severity: string
+): Promise<boolean> {
+  var r = true;
+  let children = await scan.getChildren();
+  children.forEach((element: { getLabel: () => any }) => {
+    if (element.getLabel() === severity) {
+      r = false;
+    }
+  });
+  return r;
 }
 
 export async function getDetailsView(): Promise<WebView> {
-	// Open details view
-	try {
-		let detailsView = new WebView();
-		await detailsView.switchToFrame();
-		return detailsView;
-	} catch (error) {
-		return undefined;
-	}
+  // Open details view
+  try {
+    let detailsView = new WebView();
+    await detailsView.switchToFrame();
+    return detailsView;
+  } catch (error) {
+    return undefined;
+  }
 }
 
-export async function validateNestedGroupBy(level: number, engines: any): Promise<number> {
-	let children = await engines.getChildren();
-	// Recursive case, expand and get childrens from the node
-	if (children.length > 0) {
-		await children[0].expand();
-		return validateNestedGroupBy(level + 1, children[0]);
-	}
-	// Stoppage case, when childrens list is empty
-	return level;
+export async function validateNestedGroupBy(
+  level: number,
+  engines: any
+): Promise<number> {
+  let children = await engines.getChildren();
+  // Recursive case, expand and get childrens from the node
+  if (children.length > 0) {
+    await children[0].expand();
+    return validateNestedGroupBy(level + 1, children[0]);
+  }
+  // Stoppage case, when childrens list is empty
+  return level;
 }
 
 export async function validateRootNode(scan: any): Promise<[number, any]> {
-	await scan?.expand();
-	// Validate engines type node
-	let engines = await scan?.getChildren();
-	let size = engines?.length;
-	return [size, engines];
+  await scan?.expand();
+  // Validate engines type node
+  let engines = await scan?.getChildren();
+  let size = engines?.length;
+  return [size, engines];
 }
 
-
-export const delay = (ms: number | undefined) => new Promise(res => setTimeout(res, ms));
-
+export const delay = (ms: number | undefined) =>
+  new Promise((res) => setTimeout(res, ms));

--- a/src/utils/common/constants.ts
+++ b/src/utils/common/constants.ts
@@ -68,8 +68,10 @@ export const constants = {
   sast: "sast",
   kics: "kics",
   sca: "sca",
+  scs: "sscs-secret-detection",
 
-  errorRegex: /Error: [0-9]{4}\/[0-9]{2}\/[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} /i,
+  errorRegex:
+    /Error: [0-9]{4}\/[0-9]{2}\/[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} /i,
 
   astErrorCodeBashingNoLicense: 3,
   astErrorCodeBashingNoLesson: 4,
@@ -88,8 +90,7 @@ export const constants = {
 
   // SCAN FROM IDE
   scanCreate: "$(sync~spin) Scan initializing...",
-  scanCreateVerifyBranch:
-    "$(sync~spin) Checking matching branches",
+  scanCreateVerifyBranch: "$(sync~spin) Checking matching branches",
   scanCreateVerifyFiles: "$(sync~spin) Checking matching files",
   scanCreatePreparing: "$(sync~spin) Preparing files for scan",
   scanWaiting: "$(sync~spin) Scan running",
@@ -98,8 +99,7 @@ export const constants = {
 
   // SCA AUTO SCAN
   scaNoVulnerabilities: "Checkmarx found no vulnerabilities",
-  scaStartScan:
-    "Click the play button to scan with Checkmarx SCA",
+  scaStartScan: "Click the play button to scan with Checkmarx SCA",
   clearSca: "Clear all sca scan information",
   scaScanWaiting: "$(sync~spin) Checkmarx sca scan running",
   scaScanRunningLog: "SCA auto scanning command is running",
@@ -115,8 +115,7 @@ export const constants = {
   scanStatusRunning: "running",
 
   // CREATE SCAN ADDITIONAL ARGUMENTS
-  scanCreateAdditionalParameters:
-    "--async --sast-incremental --resubmit",
+  scanCreateAdditionalParameters: "--async --sast-incremental --resubmit",
 
   treeName: "astResults",
   scaTreeName: "scaAutoScan",
@@ -171,7 +170,7 @@ export enum GroupBy {
   queryName = "queryName",
   packageIdentifier = "scaNode.packageIdentifier",
   directDependency = "scaNode.scaPackageData.typeOfDependency",
-  scaType = "scaType"
+  scaType = "scaType",
 }
 
 export enum SeverityLevel {
@@ -190,5 +189,5 @@ export enum StateLevel {
   proposed = "Proposed",
   notExploitable = "NotExploitable",
   notIgnored = "NotIgnored",
-  ignored = "Ignored"
+  ignored = "Ignored",
 }

--- a/src/utils/common/constants.ts
+++ b/src/utils/common/constants.ts
@@ -68,7 +68,8 @@ export const constants = {
   sast: "sast",
   kics: "kics",
   sca: "sca",
-  scs: "sscs-secret-detection",
+  scs: "scs",
+  scsSecretDetection: "sscs-secret-detection",
 
   errorRegex:
     /Error: [0-9]{4}\/[0-9]{2}\/[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} /i,

--- a/src/utils/interface/details.ts
+++ b/src/utils/interface/details.ts
@@ -1,23 +1,28 @@
 import { AstResult } from "../../models/results";
 import * as vscode from "vscode";
-import * as os from 'os';
+import * as os from "os";
 import { constants } from "../common/constants";
 import CxMask from "@checkmarxdev/ast-cli-javascript-wrapper/dist/main/mask/CxMask";
+import { messages } from "../common/messages";
 
 export class Details {
-	result: AstResult;
-	context: vscode.ExtensionContext;
-	iAIEnabled: boolean;
-	masked?: CxMask;
+  result: AstResult;
+  context: vscode.ExtensionContext;
+  iAIEnabled: boolean;
+  masked?: CxMask;
 
-	constructor(result: AstResult, context: vscode.ExtensionContext, iAIEnabled: boolean) {
-		this.result = result;
-		this.context = context;
-		this.iAIEnabled = iAIEnabled;
-	}
+  constructor(
+    result: AstResult,
+    context: vscode.ExtensionContext,
+    iAIEnabled: boolean
+  ) {
+    this.result = result;
+    this.context = context;
+    this.iAIEnabled = iAIEnabled;
+  }
 
-	header(severityPath: vscode.Uri) {
-		return `
+  header(severityPath: vscode.Uri) {
+    return `
 			<div class="header-container">
 				<div class="header-item-title">
 					<h2 id="cx_title">
@@ -28,10 +33,12 @@ export class Details {
 			</div>
 			<hr class="division"/>
 			`;
-	}
+  }
 
-	changes(selectClassname): string {
-		return this.triage(selectClassname) + `
+  changes(selectClassname): string {
+    return (
+      this.triage(selectClassname) +
+      `
 			<div id="history-container-loader">
 				<center>
 					<p class="history-container-loader">
@@ -41,47 +48,52 @@ export class Details {
 					</div>
 				</center>
 			</div>
-			`;
-	}
+			`
+    );
+  }
 
-	triage(selectClassname: string) {
-		const state = constants.state.filter((element) => {
-			return !!element.dependency === (this.result.type === constants.sca);
-		});
-		const updateButton =
-			this.result.type !== constants.sca ? `<button class="submit">Update</button>` : ``;
-		const comment =
-			this.result.type !== constants.sca
-				? `<div class="comment-container">
+  triage(selectClassname: string) {
+    const state = constants.state.filter((element) => {
+      return !!element.dependency === (this.result.type === constants.sca);
+    });
+    const updateButton =
+      this.result.type !== constants.sca
+        ? `<button class="submit">Update</button>`
+        : ``;
+    const comment =
+      this.result.type !== constants.sca
+        ? `<div class="comment-container">
 				<textarea placeholder="Comment (optional)" cols="41" rows="3" class="comments" type="text" id="comment_box"></textarea>
 			</div>`
-				: ``;
+        : ``;
 
-		return `<div class="ast-triage">
+    return `<div class="ast-triage">
 				<select id="select_severity" onchange="this.className=this.options[this.selectedIndex].className" class=${selectClassname}>
 					${constants.status.map((element) => {
-			return `<option id=${element.value} class="${element.class}" ${this.result.severity === element.value ? "selected" : ""
-				}>
+            return `<option id=${element.value} class="${element.class}" ${
+              this.result.severity === element.value ? "selected" : ""
+            }>
 									${element.value}	
 								</option>`;
-		})}
+          })}
 				</select>
 				<select id="select_state" class="state">
 					${state.map((element) => {
-			return `<option id=${element.value} ${this.result.state === element.tag ? 'selected="selected"' : ""
-				}>
+            return `<option id=${element.value} ${
+              this.result.state === element.tag ? 'selected="selected"' : ""
+            }>
 											${element.value}	
 										</option>`;
-		})}
+          })}
 				</select>
 			</div>
 			${comment}
 			${updateButton}
 			</br>`;
-	}
+  }
 
-	generalTab(cxPath: vscode.Uri) {
-		return `<body>
+  generalTab(cxPath: vscode.Uri) {
+    return `<body>
 				<span class="details">
 					${this.result.description ? "<p>" + this.result.description + "</p>" : ""}
 					${this.result.data.value ? this.result.getKicsValues() : ""}
@@ -93,21 +105,21 @@ export class Details {
 					</tbody>
 				</table>	
 			</body>`;
-	}
+  }
 
-	scaView(
-		severityPath,
-		scaAtackVector,
-		scaComplexity,
-		scaAuthentication,
-		scaConfidentiality,
-		scaIntegrity,
-		scaAvailability,
-		scaUpgrade,
-		scaUrl: vscode.Uri,
-		type?: string
-	) {
-		return `
+  scaView(
+    severityPath,
+    scaAtackVector,
+    scaComplexity,
+    scaAuthentication,
+    scaConfidentiality,
+    scaIntegrity,
+    scaAvailability,
+    scaUpgrade,
+    scaUrl: vscode.Uri,
+    type?: string
+  ) {
+    return `
 			<body class="body-sca">
 			<div class="header">
 				<img alt="icon" class="header-severity" src="${severityPath}" />
@@ -115,32 +127,33 @@ export class Details {
 					${this.result.label}
 				</p>
 				<p class="header-name">
-					${this.result.scaNode.packageIdentifier
-				? this.result.scaNode.packageIdentifier
-				: ""
-			}
+					${
+            this.result.scaNode.packageIdentifier
+              ? this.result.scaNode.packageIdentifier
+              : ""
+          }
 				</p>
 			</div>
 			<div class="content">
 				${this.result.scaContent(
-				this.result,
-				scaUpgrade,
-				scaUrl,
-				scaAtackVector,
-				scaComplexity,
-				scaAuthentication,
-				scaConfidentiality,
-				scaIntegrity,
-				scaAvailability,
-				type
-			)}
+          this.result,
+          scaUpgrade,
+          scaUrl,
+          scaAtackVector,
+          scaComplexity,
+          scaAuthentication,
+          scaConfidentiality,
+          scaIntegrity,
+          scaAvailability,
+          type
+        )}
 			</div>
 		</body>			
 		`;
-	}
+  }
 
-	detailsTab() {
-		return `
+  detailsTab() {
+    return `
 			<div>
 				<div id="learn-container-loader">
 					<center>
@@ -153,76 +166,113 @@ export class Details {
 				</div>
 			</div>
 			`;
-	}
+  }
 
-	// Generic tab component
-	tab(
-		tab1Content: string,
-		tab2Content: string,
-		tab3Content: string,
-		tab1Label: string,
-		tab2Label: string,
-		tab3Label: string,
-		tab4Label: string,
-		tab5Content: string,
-		tab6Label: string,
-		tab6Content: string,
-	) {
-		return `${tab1Label !== ""
-			? `<input type="radio" name="tabs" id="general-tab" checked />
+  scsDetailsRemediationTab() {
+    const remediationAdditional = this.result.data?.remediationAdditional;
+
+    if (!remediationAdditional) {
+      return `<div>${messages.noRemediationExamplesTab}</div>`;
+    }
+
+    return `
+	  <div>
+		${remediationAdditional ? `<p>${remediationAdditional}</p>` : ""}
+	  </div>
+	`;
+  }
+
+  scsDetailsDescriptionTab() {
+    const ruleDescription = this.result.data?.ruleDescription;
+
+    if (!ruleDescription) {
+      return "";
+    }
+
+    return `
+	  <div>
+	  ${ruleDescription ? `<p>${ruleDescription}</p>` : ""}
+	  </div>
+	`;
+  }
+
+  // Generic tab component
+  tab(
+    tab1Content: string,
+    tab2Content: string,
+    tab3Content: string,
+    tab1Label: string,
+    tab2Label: string,
+    tab3Label: string,
+    tab4Label: string,
+    tab5Content: string,
+    tab6Label: string,
+    tab6Content: string
+  ) {
+    return `${
+      tab1Label !== ""
+        ? `<input type="radio" name="tabs" id="general-tab" checked />
 			<label for="general-tab" id="general-label">
 				${tab1Label}
 			</label>`
-			: ""
-			}
-			${tab2Label !== ""
-				? `<input type="radio" name="tabs" id="learn-tab" />
+        : ""
+    }
+			${
+        tab2Label !== ""
+          ? `<input type="radio" name="tabs" id="learn-tab" />
 			<label for="learn-tab" id="learn-label">
 				${tab2Label}
 			</label>`
-				: ""
-			}
-			${tab4Label !== ""
-				? `<input type="radio" name="tabs" id="code-tab" />
+          : ""
+      }
+			${
+        tab4Label !== ""
+          ? `<input type="radio" name="tabs" id="code-tab" />
 			<label for="code-tab" id="code-label">
 				${tab4Label}
 			</label>`
-				: ""
-			}
-			${tab6Label !== ""
-				? `<input type="radio" name="tabs" id="ai-tab" />
+          : ""
+      }
+			${
+        tab6Label !== ""
+          ? `<input type="radio" name="tabs" id="ai-tab" />
 			<label for="ai-tab" id="ai-label">
 				${tab6Label}
 			</label>`
-				: ""
-			}
-			${tab3Label !== ""
-			? `<input type="radio" name="tabs" id="changes-tab" />
+          : ""
+      }
+			${
+        tab3Label !== ""
+          ? `<input type="radio" name="tabs" id="changes-tab" />
 		<label for="changes-tab" id="changes-label">
 			${tab3Label}
 		</label>`
-			: ""
-		}
-			${tab1Content !== ""
-				? `<div class="tab general">
+          : ""
+      }
+			${
+        tab1Content !== ""
+          ? `<div class="tab general">
 			${tab1Content}
 			</div>`
-				: ""
-			}
-			${tab2Content !== ""
-				? `<div class="tab learn">
+          : ""
+      }
+			${
+        tab2Content !== ""
+          ? `<div class="tab learn">
 			${tab2Content}
 			</div>`
-				: ""
-			}
-			${tab3Content !== ""
-				? `<div class="tab changes">
+          : ""
+      }
+			${
+        tab3Content !== ""
+          ? `<div class="tab changes">
 			${tab3Content}
 		</div>`
-				: ""
-			}
-		${tab5Content !== ""
-				? `<div class="tab code">
+          : ""
+      }
+		${
+      tab5Content !== ""
+        ? `<div class="tab code">
 		<div id="tab-code">
 			<pre class="pre-code">
 				<code id="code">
@@ -231,19 +281,20 @@ export class Details {
 			</pre>
 		</div>
 	</div>`
-				: ""
-			}
-			${tab6Content !== ""
-				? `<div class="tab ai">
+        : ""
+    }
+			${
+        tab6Content !== ""
+          ? `<div class="tab ai">
 					${tab6Content}
 				  </div>`
-				: ""
-			}
+          : ""
+      }
 			`;
-	}
-	guidedRemediationSastTab(kicsIcon, masked: CxMask) {
-		this.masked = masked;
-		return `
+  }
+  guidedRemediationSastTab(kicsIcon, masked: CxMask) {
+    this.masked = masked;
+    return `
 		<div class="inner-body-sast" id="innerBodySast" style="min-height: 80vh;display: flex;justify-content: center;align-items: center;">
 		<button id="startSastChat" class="start-sast-chat">
 			<div class="row">
@@ -261,14 +312,15 @@ export class Details {
 		</button>
 		</div>
 		`;
-	}
+  }
 
-	guidedRemediationTab(kicsIcon, masked: CxMask) { // TODO: try to make it generic to be used by the tab and the webview
-		this.masked = masked;
-		const userInfo = os.userInfo();
-		// Access the username
-		const username = userInfo.username;
-		return `
+  guidedRemediationTab(kicsIcon, masked: CxMask) {
+    // TODO: try to make it generic to be used by the tab and the webview
+    this.masked = masked;
+    const userInfo = os.userInfo();
+    // Access the username
+    const username = userInfo.username;
+    return `
 		<div class="inner-body">
 		<div>
 	<div class="container" style="padding:0;width:100 !important;">
@@ -285,7 +337,9 @@ export class Details {
 				<div class="row" style="margin-top:0.8em">
 					<div class="col">
 						<p>Welcome ${username}!</p>
-						<p>”${constants.aiSecurityChampion}” harnesses the power of AI to help you to understand the
+						<p>”${
+              constants.aiSecurityChampion
+            }” harnesses the power of AI to help you to understand the
 							vulnerabilities in your code, and resolve them quickly and easily.</p>
 						<p style="margin-bottom:0">We protect your sensitive data by anonymizing the source file
 							before sending data to GPT.</p>
@@ -295,12 +349,16 @@ export class Details {
 					<div id="accordion" style="width:100%">
 						<div class="card" style="background:transparent;">
 							<div class="card-header" id="headingOne" style="padding:0!important">
-								<h5 class="mb-0">
+								<h5 class="mb-0">import { messages } from '../common/messages';
+
 									<button class="btn btn-link" data-toggle="collapse" data-target="#collapseOne"
 										aria-expanded="true" aria-controls="collapseOne"
 										style="color:var(--vscode-editor-foreground);text-align:left">
-										Masked Secrets ${this.masked && this.masked.maskedSecrets ? "(" +
-				this.masked.maskedSecrets.length + ")" : ""}
+										Masked Secrets ${
+                      this.masked && this.masked.maskedSecrets
+                        ? "(" + this.masked.maskedSecrets.length + ")"
+                        : ""
+                    }
 									</button>
 								</h5>
 							</div>
@@ -376,7 +434,9 @@ export class Details {
 		<div class="row" style="margin-top:1em">
 			<div class="col">
 				<p style="color:#676972;font-size:12px">
-					”${constants.aiSecurityChampion}” will only answer questions that are relevant to this IaC file and its
+					”${
+            constants.aiSecurityChampion
+          }” will only answer questions that are relevant to this IaC file and its
 					results.The responses are generated by OpenAI's GPT. The content may contain inaccuracies. Use
 					your judgement in determining how to utilize this information.
 				</p>
@@ -418,17 +478,31 @@ export class Details {
 </button>
 </div>
 		`;
-	}
+  }
 
-	generateMaskedSection(): string {
-		let html = "";
-		if (this.masked && this.masked.maskedSecrets && this.masked.maskedSecrets.length > 0) {
-			for (let i = 0; i < this.masked.maskedSecrets.length; i++) {
-				html += "<p>Secret: " + this.masked.maskedSecrets[i].secret + "<br/>" + "Masked: " + this.masked.maskedSecrets[i].masked.replaceAll("<", "&lt;").replaceAll(">", "&gt;") + "<br/>Line: " + this.masked.maskedSecrets[i].line + "</p>";
-			}
-		} else {
-			html += "No secrets were detected and masked";
-		}
-		return html;
-	}
+  generateMaskedSection(): string {
+    let html = "";
+    if (
+      this.masked &&
+      this.masked.maskedSecrets &&
+      this.masked.maskedSecrets.length > 0
+    ) {
+      for (let i = 0; i < this.masked.maskedSecrets.length; i++) {
+        html +=
+          "<p>Secret: " +
+          this.masked.maskedSecrets[i].secret +
+          "<br/>" +
+          "Masked: " +
+          this.masked.maskedSecrets[i].masked
+            .replaceAll("<", "&lt;")
+            .replaceAll(">", "&gt;") +
+          "<br/>Line: " +
+          this.masked.maskedSecrets[i].line +
+          "</p>";
+      }
+    } else {
+      html += "No secrets were detected and masked";
+    }
+    return html;
+  }
 }

--- a/src/views/resultsProviders.ts
+++ b/src/views/resultsProviders.ts
@@ -56,8 +56,8 @@ export class ResultsProvider implements vscode.TreeDataProvider<TreeItem> {
     if (result.label) {
       return result.label;
     }
-    if (result.type === "sscs-secret-detection") {
-      return "scs";
+    if (result.type === constants.scsSecretDetection) {
+      return constants.scs;
     }
     return undefined;
   }

--- a/src/views/resultsProviders.ts
+++ b/src/views/resultsProviders.ts
@@ -1,196 +1,222 @@
 import * as vscode from "vscode";
 import { EventEmitter } from "vscode";
 import { TreeItem } from "../utils/tree/treeItem";
-import { GroupBy, SeverityLevel, StateLevel, constants } from "../utils/common/constants";
+import {
+  GroupBy,
+  SeverityLevel,
+  StateLevel,
+  constants,
+} from "../utils/common/constants";
 import CxResult from "@checkmarxdev/ast-cli-javascript-wrapper/dist/main/results/CxResult";
 import { Counter } from "../models/counter";
 import { AstResult } from "../models/results";
 import { SastNode } from "../models/sastNode";
 import { getProperty } from "../utils/utils";
 export class ResultsProvider implements vscode.TreeDataProvider<TreeItem> {
-	protected _onDidChangeTreeData: EventEmitter<TreeItem | undefined> =
-		new EventEmitter<TreeItem | undefined>();
-	readonly onDidChangeTreeData: vscode.Event<TreeItem | undefined> =
-		this._onDidChangeTreeData.event;
-	protected data: TreeItem[] | undefined;
-	constructor(
-		protected readonly context: vscode.ExtensionContext,
-		protected readonly statusBarItem: vscode.StatusBarItem,
-	) {
-	}
+  protected _onDidChangeTreeData: EventEmitter<TreeItem | undefined> =
+    new EventEmitter<TreeItem | undefined>();
+  readonly onDidChangeTreeData: vscode.Event<TreeItem | undefined> =
+    this._onDidChangeTreeData.event;
+  protected data: TreeItem[] | undefined;
+  constructor(
+    protected readonly context: vscode.ExtensionContext,
+    protected readonly statusBarItem: vscode.StatusBarItem
+  ) {}
 
-	public getTreeItem(element: TreeItem): vscode.TreeItem | Thenable<vscode.TreeItem> {
-		return element;
-	}
+  public getTreeItem(
+    element: TreeItem
+  ): vscode.TreeItem | Thenable<vscode.TreeItem> {
+    return element;
+  }
 
-	public getChildren(
-		element?: TreeItem | undefined
-	): vscode.ProviderResult<TreeItem[]> {
-		if (element === undefined) {
-			return this.data;
-		}
-		return element.children;
-	}
-	protected hideStatusBarItem() {
-		this.statusBarItem.text = constants.extensionName;
-		this.statusBarItem.tooltip = undefined;
-		this.statusBarItem.command = undefined;
-		this.statusBarItem.hide();
-	}
-	protected showStatusBarItem(message: string) {
-		this.statusBarItem.text = constants.refreshingTree;
-		this.statusBarItem.tooltip = message;
-		this.statusBarItem.show();
-	}
-	public refresh(): void {
-		this._onDidChangeTreeData.fire(undefined);
-	}
+  public getChildren(
+    element?: TreeItem | undefined
+  ): vscode.ProviderResult<TreeItem[]> {
+    if (element === undefined) {
+      return this.data;
+    }
+    return element.children;
+  }
+  protected hideStatusBarItem() {
+    this.statusBarItem.text = constants.extensionName;
+    this.statusBarItem.tooltip = undefined;
+    this.statusBarItem.command = undefined;
+    this.statusBarItem.hide();
+  }
+  protected showStatusBarItem(message: string) {
+    this.statusBarItem.text = constants.refreshingTree;
+    this.statusBarItem.tooltip = message;
+    this.statusBarItem.show();
+  }
+  public refresh(): void {
+    this._onDidChangeTreeData.fire(undefined);
+  }
 
-	public createSummaryItem(list: CxResult[]): TreeItem {
-		const counter = new Counter(list, (p: CxResult) => p.severity);
-		const label = Array.from(counter.keys())
-			.map((key) => `${key}: ${counter.get(key)}`)
-			.join(" | ");
-		return new TreeItem(label, constants.graphItem, undefined);
-	}
+  public determineTypeLabel(result: CxResult): string | undefined {
+    if (result.label) {
+      return result.label;
+    }
+    if (result.type === "sscs-secret-detection") {
+      return "scs";
+    }
+    return undefined;
+  }
 
-	public groupBy(
-		list: object[],
-		groups: string[],
-		scan: string | undefined,
-		diagnosticCollection: vscode.DiagnosticCollection,
-		issueLevel: string[] = [
-			SeverityLevel.critical,
-			SeverityLevel.high,
-			SeverityLevel.medium,
-			SeverityLevel.low,
-			SeverityLevel.info,
-		],
-		stateLevel: string[] = [
-			StateLevel.confirmed,
-			StateLevel.toVerify,
-			StateLevel.urgent,
-			StateLevel.notIgnored,
-		]
-	): TreeItem {
-		const folder = vscode.workspace.workspaceFolders?.[0];
-		const map = new Map<string, vscode.Diagnostic[]>();
+  public createSummaryItem(list: CxResult[]): TreeItem {
+    const filteredList = list.filter((result: CxResult) =>
+      this.determineTypeLabel(result)
+    );
+    const counter = new Counter(filteredList, (p: CxResult) => p.severity);
+    const label = Array.from(counter.keys())
+      .map((key) => `${key}: ${counter.get(key)}`)
+      .join(" | ");
+    return new TreeItem(label, constants.graphItem, undefined);
+  }
 
-		const tree = new TreeItem(scan ?? "", undefined, undefined, []);
-		list.forEach((element: object) => {
-			this.groupTree(element, folder, map, groups, tree, issueLevel, stateLevel);
-		});
+  public groupBy(
+    list: object[],
+    groups: string[],
+    scan: string | undefined,
+    diagnosticCollection: vscode.DiagnosticCollection,
+    issueLevel: string[] = [
+      SeverityLevel.critical,
+      SeverityLevel.high,
+      SeverityLevel.medium,
+      SeverityLevel.low,
+      SeverityLevel.info,
+    ],
+    stateLevel: string[] = [
+      StateLevel.confirmed,
+      StateLevel.toVerify,
+      StateLevel.urgent,
+      StateLevel.notIgnored,
+    ]
+  ): TreeItem {
+    const folder = vscode.workspace.workspaceFolders?.[0];
+    const map = new Map<string, vscode.Diagnostic[]>();
 
-		diagnosticCollection.clear();
-		map.forEach((value, key) =>
-			diagnosticCollection.set(vscode.Uri.parse(key), value)
-		);
+    const tree = new TreeItem(scan ?? "", undefined, undefined, []);
+    list.forEach((element: object) => {
+      this.groupTree(
+        element,
+        folder,
+        map,
+        groups,
+        tree,
+        issueLevel,
+        stateLevel
+      );
+    });
 
-		return tree;
-	}
+    diagnosticCollection.clear();
+    map.forEach((value, key) =>
+      diagnosticCollection.set(vscode.Uri.parse(key), value)
+    );
 
-	private groupTree(
-		rawObj: object,
-		folder: vscode.WorkspaceFolder | undefined,
-		map: Map<string, vscode.Diagnostic[]>,
-		groups: string[],
-		tree: TreeItem,
-		issueLevel: string[],
-		stateLevel: string[]
-	) {
-		const obj = new AstResult(rawObj);
-		if (!obj) {
-			return;
-		}
-		const item = new TreeItem(obj.label.replaceAll("_", " "), undefined, obj);
-		let node;
-		// Verify the current severity filters applied
-		if (issueLevel.length > 0) {
-			// Filter only the results for the severity and state filters type
-			if (
-				(!obj.getState() || issueLevel.includes(obj.getSeverity())) &&
-				(!obj.getState() || stateLevel.includes(obj.getState()))
-			) {
-				if (obj.sastNodes.length > 0) {
-					this.createDiagnostic(
-						obj.label,
-						obj.getSeverityCode(),
-						obj.sastNodes[0],
-						folder,
-						map
-					);
-				}
-				node = groups.reduce(
-					(previousValue: TreeItem, currentValue: string) =>
-						this.reduceGroups(obj, previousValue, currentValue),
-					tree
-				);
-				node.children?.push(item);
-			}
-		}
-	}
+    return tree;
+  }
 
-	private createDiagnostic(
-		label: string,
-		severity: vscode.DiagnosticSeverity,
-		node: SastNode,
-		folder: vscode.WorkspaceFolder | undefined,
-		map: Map<string, vscode.Diagnostic[]>
-	) {
-		if (!folder) {
-			return;
-		}
-		const filePath = vscode.Uri.joinPath(folder?.uri, node.fileName).toString();
-		// Needed because vscode uses zero based line number
-		const column = node.column > 0 ? +node.column - 1 : 1;
-		const line = node.line > 0 ? +node.line - 1 : 1;
-		const length = column + node.length;
-		const startPosition = new vscode.Position(line, column);
-		const endPosition = new vscode.Position(line, length);
-		const range = new vscode.Range(startPosition, endPosition);
+  private groupTree(
+    rawObj: object,
+    folder: vscode.WorkspaceFolder | undefined,
+    map: Map<string, vscode.Diagnostic[]>,
+    groups: string[],
+    tree: TreeItem,
+    issueLevel: string[],
+    stateLevel: string[]
+  ) {
+    const obj = new AstResult(rawObj);
+    if (!obj || !obj.typeLabel) {
+      return;
+    }
+    const item = new TreeItem(obj.label.replaceAll("_", " "), undefined, obj);
+    let node;
+    // Verify the current severity filters applied
+    if (issueLevel.length > 0) {
+      // Filter only the results for the severity and state filters type
+      if (
+        (!obj.getState() || issueLevel.includes(obj.getSeverity())) &&
+        (!obj.getState() || stateLevel.includes(obj.getState()))
+      ) {
+        if (obj.sastNodes.length > 0) {
+          this.createDiagnostic(
+            obj.label,
+            obj.getSeverityCode(),
+            obj.sastNodes[0],
+            folder,
+            map
+          );
+        }
+        node = groups.reduce(
+          (previousValue: TreeItem, currentValue: string) =>
+            this.reduceGroups(obj, previousValue, currentValue),
+          tree
+        );
+        node.children?.push(item);
+      }
+    }
+  }
 
-		const diagnostic = new vscode.Diagnostic(range, label, severity);
-		if (map.has(filePath)) {
-			map.get(filePath)?.push(diagnostic);
-		} else {
-			map.set(filePath, [diagnostic]);
-		}
-	}
+  private createDiagnostic(
+    label: string,
+    severity: vscode.DiagnosticSeverity,
+    node: SastNode,
+    folder: vscode.WorkspaceFolder | undefined,
+    map: Map<string, vscode.Diagnostic[]>
+  ) {
+    if (!folder) {
+      return;
+    }
+    const filePath = vscode.Uri.joinPath(folder?.uri, node.fileName).toString();
+    // Needed because vscode uses zero based line number
+    const column = node.column > 0 ? +node.column - 1 : 1;
+    const line = node.line > 0 ? +node.line - 1 : 1;
+    const length = column + node.length;
+    const startPosition = new vscode.Position(line, column);
+    const endPosition = new vscode.Position(line, length);
+    const range = new vscode.Range(startPosition, endPosition);
 
-	private reduceGroups(
-		obj: AstResult,
-		previousValue: TreeItem,
-		currentValue: string
-	) {
-		let value = getProperty(obj, currentValue);
+    const diagnostic = new vscode.Diagnostic(range, label, severity);
+    if (map.has(filePath)) {
+      map.get(filePath)?.push(diagnostic);
+    } else {
+      map.set(filePath, [diagnostic]);
+    }
+  }
 
-		// Needed to group by filename in kics, in case nothing is found then its a kics result and must be found inside data.filename
-		if (currentValue === GroupBy.fileName && value.length === 0) {
-			value = getProperty(obj.data, GroupBy.fileName.toLowerCase());
-		}
+  private reduceGroups(
+    obj: AstResult,
+    previousValue: TreeItem,
+    currentValue: string
+  ) {
+    let value = getProperty(obj, currentValue);
 
-		if (!value) {
-			return previousValue;
-		}
+    // Needed to group by filename in kics, in case nothing is found then its a kics result and must be found inside data.filename
+    if (currentValue === GroupBy.fileName && value.length === 0) {
+      value = getProperty(obj.data, GroupBy.fileName.toLowerCase());
+    }
 
-		const tree = previousValue.children
-			? previousValue.children.find(
-				(item) => item.label === value.replaceAll("_", " ")
-			)
-			: undefined;
-		if (tree) {
-			tree.setDescription();
-			return tree;
-		}
+    if (!value) {
+      return previousValue;
+    }
 
-		const newTree = new TreeItem(
-			value.replaceAll("_", " "),
-			undefined,
-			undefined,
-			[]
-		);
-		previousValue.children?.push(newTree);
-		return newTree;
-	}
+    const tree = previousValue.children
+      ? previousValue.children.find(
+          (item) => item.label === value.replaceAll("_", " ")
+        )
+      : undefined;
+    if (tree) {
+      tree.setDescription();
+      return tree;
+    }
 
+    const newTree = new TreeItem(
+      value.replaceAll("_", " "),
+      undefined,
+      undefined,
+      []
+    );
+    previousValue.children?.push(newTree);
+    return newTree;
+  }
 }

--- a/src/views/resultsView/astDetailsView.ts
+++ b/src/views/resultsView/astDetailsView.ts
@@ -332,7 +332,7 @@ export class AstDetailsDetached implements vscode.WebviewViewProvider {
                   scaUrl,
                   this.type
                 )
-              : this.result.type === constants.scs
+              : this.result.type === constants.scsSecretDetection
               ? html.tab(
                   html.generalTab(cxPath),
                   html.scsDetailsDescriptionTab(),

--- a/src/views/resultsView/astDetailsView.ts
+++ b/src/views/resultsView/astDetailsView.ts
@@ -22,7 +22,7 @@ export class AstDetailsDetached implements vscode.WebviewViewProvider {
     private loadChanges: boolean,
     private logs: Logs,
     private type?: string
-  ) { }
+  ) {}
 
   public getWebView() {
     return this._view;
@@ -99,9 +99,7 @@ export class AstDetailsDetached implements vscode.WebviewViewProvider {
         }
       }
       if (!fileOpened) {
-        vscode.window.showErrorMessage(
-          messages.resultFileNotFound(filePath)
-        );
+        vscode.window.showErrorMessage(messages.resultFileNotFound(filePath));
       }
     } catch (error) {
       vscode.window.showErrorMessage(messages.resultFileNotFound(filePath));
@@ -136,19 +134,44 @@ export class AstDetailsDetached implements vscode.WebviewViewProvider {
       vscode.Uri.joinPath(this._extensionUri, "media", "gpt.js")
     );
     const scriptJquery = webview.asWebviewUri(
-      vscode.Uri.joinPath(this._extensionUri, "media", "jquery", "jquery-3.7.0.min.js")
+      vscode.Uri.joinPath(
+        this._extensionUri,
+        "media",
+        "jquery",
+        "jquery-3.7.0.min.js"
+      )
     );
     const scriptBootStrap = webview.asWebviewUri(
-      vscode.Uri.joinPath(this._extensionUri, "media", "bootstrap", "bootstrap.min.js")
+      vscode.Uri.joinPath(
+        this._extensionUri,
+        "media",
+        "bootstrap",
+        "bootstrap.min.js"
+      )
     );
     const scriptHighlight = webview.asWebviewUri(
-      vscode.Uri.joinPath(this._extensionUri, "media", "codeRenderers", "highlight.min.js")
+      vscode.Uri.joinPath(
+        this._extensionUri,
+        "media",
+        "codeRenderers",
+        "highlight.min.js"
+      )
     );
     const scriptMarked = webview.asWebviewUri(
-      vscode.Uri.joinPath(this._extensionUri, "media", "codeRenderers", "marked.min.js")
+      vscode.Uri.joinPath(
+        this._extensionUri,
+        "media",
+        "codeRenderers",
+        "marked.min.js"
+      )
     );
     const scriptShowdown = webview.asWebviewUri(
-      vscode.Uri.joinPath(this._extensionUri, "media", "codeRenderers", "showdown.min.js")
+      vscode.Uri.joinPath(
+        this._extensionUri,
+        "media",
+        "codeRenderers",
+        "showdown.min.js"
+      )
     );
 
     const styleResetUri = webview.asWebviewUri(
@@ -170,7 +193,12 @@ export class AstDetailsDetached implements vscode.WebviewViewProvider {
       vscode.Uri.joinPath(this._extensionUri, "media", "gpt.css")
     );
     const styleBootStrap = webview.asWebviewUri(
-      vscode.Uri.joinPath(this._extensionUri, "media", "bootstrap", "bootstrap.min.css")
+      vscode.Uri.joinPath(
+        this._extensionUri,
+        "media",
+        "bootstrap",
+        "bootstrap.min.css"
+      )
     );
 
     const severityPath = webview.asWebviewUri(
@@ -207,10 +235,16 @@ export class AstDetailsDetached implements vscode.WebviewViewProvider {
       vscode.Uri.joinPath(this._extensionUri, this.result.getCxUrl())
     );
     const kicsIcon = webview.asWebviewUri(
-      vscode.Uri.joinPath(this._extensionUri, path.join("media", "icons", "kics.png"))
+      vscode.Uri.joinPath(
+        this._extensionUri,
+        path.join("media", "icons", "kics.png")
+      )
     );
     const kicsUserIcon = webview.asWebviewUri(
-      vscode.Uri.joinPath(this._extensionUri, path.join("media", "icons", "userKics.png"))
+      vscode.Uri.joinPath(
+        this._extensionUri,
+        path.join("media", "icons", "userKics.png")
+      )
     );
 
     const cxIcon = webview.asWebviewUri(
@@ -230,7 +264,10 @@ export class AstDetailsDetached implements vscode.WebviewViewProvider {
       try {
         const gptResult = new GptResult(this.result, undefined);
         masked = await cx.mask(gptResult.filename);
-        this.logs.info(`Masked Secrets by ${constants.aiSecurityChampion}: ` + (masked && masked.maskedSecrets ? masked.maskedSecrets.length : "0"));
+        this.logs.info(
+          `Masked Secrets by ${constants.aiSecurityChampion}: ` +
+            (masked && masked.maskedSecrets ? masked.maskedSecrets.length : "0")
+        );
       } catch (error) {
         this.logs.info(error);
       }
@@ -245,8 +282,16 @@ export class AstDetailsDetached implements vscode.WebviewViewProvider {
           <link href="${styleMainUri}" rel="stylesheet">
           <link href="${styleDetails}" rel="stylesheet">
           <link href="${scaDetails}" rel="stylesheet">
-          ${this.result.type !== "sca" ? `<link href="${styleBootStrap}" rel="stylesheet">` : ""}
-          ${this.result.type !== "sca" ? `<link href="${styleGptUri}" rel="stylesheet">` : ""}
+          ${
+            this.result.type !== "sca"
+              ? `<link href="${styleBootStrap}" rel="stylesheet">`
+              : ""
+          }
+          ${
+            this.result.type !== "sca"
+              ? `<link href="${styleGptUri}" rel="stylesheet">`
+              : ""
+          }
           <script nonce="${nonce}" src="${scriptJquery}"></script>
           <script nonce="${nonce}" src="${scriptBootStrap}"></script>
           <script nonce="${nonce}" src="${scriptHighlight}"></script>
@@ -258,45 +303,61 @@ export class AstDetailsDetached implements vscode.WebviewViewProvider {
         </head>
         <div id="main_div">
           ${this.result.type !== "sca" ? html.header(severityPath) : ""}
-          ${this.result.type === "sast"
-        ? html.tab(
-          html.generalTab(cxPath),
-          html.detailsTab(),
-          html.changes(selectClassname),
-          messages.generalTab,
-          messages.descriptionTab,
-          messages.triageTab,
-          messages.remediationExamplesTab,
-          messages.noRemediationExamplesTab,
-          isAIEnabled ? `${constants.aiSecurityChampion}` : "",
-          isAIEnabled ? html.guidedRemediationSastTab(cxIcon, masked) : ""
-        )
-        : this.result.type === "sca"
-          ? html.scaView(
-            severityPath,
-            scaAtackVector,
-            scaComplexity,
-            scaAuthentication,
-            scaConfidentiality,
-            scaIntegrity,
-            scaAvailability,
-            scaUpgrade,
-            scaUrl,
-            this.type
-          )
-          : html.tab(
-            html.generalTab(cxPath),
-            "",
-            html.changes(selectClassname),
-            messages.generalTab,
-            "",
-            messages.triageTab,
-            "",
-            "",
-            isAIEnabled ? `${constants.aiSecurityChampion}` : "",
-            isAIEnabled ? html.guidedRemediationTab(kicsIcon, masked) : ""
-          )
-      }
+          ${
+            this.result.type === "sast"
+              ? html.tab(
+                  html.generalTab(cxPath),
+                  html.detailsTab(),
+                  html.changes(selectClassname),
+                  messages.generalTab,
+                  messages.descriptionTab,
+                  messages.triageTab,
+                  messages.remediationExamplesTab,
+                  messages.noRemediationExamplesTab,
+                  isAIEnabled ? `${constants.aiSecurityChampion}` : "",
+                  isAIEnabled
+                    ? html.guidedRemediationSastTab(cxIcon, masked)
+                    : ""
+                )
+              : this.result.type === "sca"
+              ? html.scaView(
+                  severityPath,
+                  scaAtackVector,
+                  scaComplexity,
+                  scaAuthentication,
+                  scaConfidentiality,
+                  scaIntegrity,
+                  scaAvailability,
+                  scaUpgrade,
+                  scaUrl,
+                  this.type
+                )
+              : this.result.type === constants.scs
+              ? html.tab(
+                  html.generalTab(cxPath),
+                  html.scsDetailsDescriptionTab(),
+                  html.scsDetailsRemediationTab(),
+                  messages.generalTab,
+                  messages.descriptionTab,
+                  messages.remediationExamplesTab,
+                  "",
+                  "",
+                  "",
+                  ""
+                )
+              : html.tab(
+                  html.generalTab(cxPath),
+                  "",
+                  html.changes(selectClassname),
+                  messages.generalTab,
+                  "",
+                  messages.triageTab,
+                  "",
+                  "",
+                  isAIEnabled ? `${constants.aiSecurityChampion}` : "",
+                  isAIEnabled ? html.guidedRemediationTab(kicsIcon, masked) : ""
+                )
+          }
         </div>
         <script>
           const vscode = acquireVsCodeApi();


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct]

### Description

> Support SCS Secret Detection in the VSCode Plugin with grouping and filtering functionality, as well as a Vulnerability Tab.

### References

> https://checkmarx.atlassian.net/browse/AST-63908

### Testing

> Load SCS Results and Group by Different Types: Validate that SCS results are loaded and correctly grouped by various supported types.

>Load SCS Results and Filter by Different Types: Ensure that SCS results are loaded and properly filtered according to different criteria.

>Expand SCS Vulnerability (Vulnerability Tab with Sub-tabs): Confirm that expanding an SCS vulnerability opens the Vulnerability Tab, displaying its detailed sub-tabs.
>
> UI Tests. (in progress)

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR (if applicable).
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used