### PR TITLE
Enhance format additional parameters by replacing spaces with commas (AST-65670)

### DIFF
--- a/src/kics/kicsRealtimeProvider.ts
+++ b/src/kics/kicsRealtimeProvider.ts
@@ -299,7 +299,7 @@ export class KicsProvider {
       let additionalParams = vscode.workspace
         .getConfiguration("CheckmarxKICS")
         .get("Additional Parameters") as string;
-        additionalParams = additionalParams.replace(/\s+/g, ",");
+        additionalParams = additionalParams.replace(/("[^"]*")|\s+/g, (match, quoted) => quoted ? quoted : ",");
       if (file) {
         results = await cx.getResultsRealtime(file, additionalParams);
       } else {

--- a/src/kics/kicsRealtimeProvider.ts
+++ b/src/kics/kicsRealtimeProvider.ts
@@ -296,9 +296,10 @@ export class KicsProvider {
   async createKicsScan(file: string | undefined) {
     let results;
     try {
-      const additionalParams = vscode.workspace
+      let additionalParams = vscode.workspace
         .getConfiguration("CheckmarxKICS")
         .get("Additional Parameters") as string;
+        additionalParams = additionalParams.replace(/\s+/g, ",");
       if (file) {
         results = await cx.getResultsRealtime(file, additionalParams);
       } else {


### PR DESCRIPTION


### Description

>  Kics scan fails with error 126 
Enhance createKicsScan function to format additional parameters
 by replacing spaces with commas before executing the scan

### References

>https://checkmarx.atlassian.net/browse/AST-65670

### Testing

> Describe how this change was tested. Be specific about anything not tested and reasons why. If this solution has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR (if applicable).
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used