### PR TITLE
Enabling the button after create scan failure (AST-77386)

### DIFF
--- a/src/views/resultsView/createScanProvider.ts
+++ b/src/views/resultsView/createScanProvider.ts
@@ -13,6 +13,7 @@ import { getResultsJson, updateStatusBarItem } from "../../utils/utils";
 import { messages } from "../../utils/common/messages";
 import { commands } from "../../utils/common/commands";
 import { loadScanId } from "../../utils/pickers/pickers";
+import { setScanButtonDefaultIfScanIsNotRunning } from "../../utils/listener/listeners";
 
 export async function pollForScanResult(
   context: vscode.ExtensionContext,
@@ -153,8 +154,12 @@ export async function createScan(
   }
 
   updateStatusBarItem(constants.scanCreatePreparing, true, statusBarItem);
-  await createScanForProject(context, logs);
-
+  try {
+    await createScanForProject(context, logs);
+  } catch (error) {
+      setScanButtonDefaultIfScanIsNotRunning(context);
+    throw error;
+  }
   updateStatusBarItem(constants.scanWaiting, true, statusBarItem);
   updateState(context, constants.scanCreatePrepKey, { id: false, name: "", displayScanId: undefined, scanDatetime: undefined });
 


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](../docs/code_of_conduct.md). Please see the [contributing guidelines](../docs/contributing.md) for how to create and submit a high-quality PR for this repo.

### Description

Catching the error returned from CX and clearing scan-related states.

### References

https://checkmarx.atlassian.net/browse/AST-77386

### Testing

> Describe how this change was tested. Be specific about anything not tested and reasons why. If this solution has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR (if applicable).
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used