### PR TITLE
VS CODE | Adding a warning for the user when the SCM project doesn't match the CX project (AST-78313)

### DIFF
--- a/src/test/10.localBranch.test.ts
+++ b/src/test/10.localBranch.test.ts
@@ -6,8 +6,10 @@ import {
 	WebDriver,
 	Workbench,
 } from "vscode-extension-tester";
-import { expect } from "chai";
-import { getQuickPickSelector, initialize } from "./utils/utils";
+import { messages } from "../utils/common/messages";
+
+import {expect} from "chai";
+import {getQuickPickSelector, initialize} from "./utils/utils";
 import {
 	BRANCH_KEY_TREE,
 	CX_CLEAR,
@@ -163,8 +165,14 @@ describe("Using a local branch if Git exists", () => {
 	it("should run scan with local branch", retryTest(async function () {
 		await bench.executeCommand("ast-results.createScan");
 
-		const firstNotification = waitForNotificationWithTimeout(5000)
-		expect(firstNotification).is.not.undefined;
+        let firstNotification = await waitForNotificationWithTimeout(5000)
+        let message = await firstNotification?.getMessage();
+        if (message === messages.scanProjectNotMatch) {
+            await firstNotification?.getActions()[0].click();
+            const resultsNotifications = await new Workbench().getNotifications();
+            firstNotification = resultsNotifications[0];
+        }
+        expect(firstNotification).is.not.undefined;
 
 	}, 3));
 

--- a/src/test/10.localBranch.test.ts
+++ b/src/test/10.localBranch.test.ts
@@ -1,23 +1,22 @@
 import {
-	CustomTreeSection,
-	EditorView,
-	InputBox,
-	VSBrowser,
-	WebDriver,
-	Workbench,
+    CustomTreeSection,
+    EditorView,
+    InputBox,
+    VSBrowser,
+    WebDriver,
+    Workbench,
 } from "vscode-extension-tester";
 import { messages } from "../utils/common/messages";
-
 import {expect} from "chai";
-import {getQuickPickSelector, initialize} from "./utils/utils";
+import {getQuickPickSelector, initialize, sleep, waitForNotificationWithTimeout} from "./utils/utils";
 import {
-	BRANCH_KEY_TREE,
-	CX_CLEAR,
-	CX_SELECT_BRANCH,
-	CX_SELECT_PROJECT,
-	CX_SELECT_SCAN,
-	PROJECT_KEY_TREE,
-	SCAN_KEY_TREE_LABEL,
+    BRANCH_KEY_TREE,
+    CX_CLEAR,
+    CX_SELECT_BRANCH,
+    CX_SELECT_PROJECT,
+    CX_SELECT_SCAN,
+    PROJECT_KEY_TREE,
+    SCAN_KEY_TREE_LABEL,
 } from "./utils/constants";
 import { CX_TEST_SCAN_PROJECT_NAME } from "./utils/envs";
 import { constants } from "../utils/common/constants";
@@ -26,21 +25,21 @@ import * as fs from "fs";
 
 
 function retryTest(testFn, retries = 3) {
-	return async function () {
-		let lastError;
-		for (let attempt = 1; attempt <= retries; attempt++) {
-			try {
-				await testFn();
-				return;
-			} catch (error) {
-				lastError = error;
-				console.warn(`Retrying test... Attempt ${attempt} of ${retries}`);
-				if (attempt === retries) {
-					throw lastError;
-				}
-			}
-		}
-	};
+    return async function () {
+        let lastError;
+        for (let attempt = 1; attempt <= retries; attempt++) {
+            try {
+                await testFn();
+                return;
+            } catch (error) {
+                lastError = error;
+                console.warn(`Retrying test... Attempt ${attempt} of ${retries}`);
+                if (attempt === retries) {
+                    throw lastError;
+                }
+            }
+        }
+    };
 }
 
 function switchToBranch(branchName: string) {
@@ -54,17 +53,13 @@ function switchToBranch(branchName: string) {
 
 }
 
-async function sleep(ms: number) {
-	return await new Promise(resolve => setTimeout(resolve, ms));
-}
-
 async function selectItem(text) {
-	const input = await InputBox.create();
-	await input.setText(text);
-	let item = await getQuickPickSelector(input);
-	await input.setText(item);
-	await input.confirm();
-	return item;
+    const input = await InputBox.create();
+    await input.setText(text);
+    let item = await getQuickPickSelector(input);
+    await input.setText(item);
+    await input.confirm();
+    return item;
 }
 
 async function waitForNotificationWithTimeout(timeout) {
@@ -90,14 +85,14 @@ async function waitForNotificationWithTimeout(timeout) {
 }
 
 describe("Using a local branch if Git exists", () => {
-	let bench: Workbench;
-	let treeScans: CustomTreeSection;
-	let driver: WebDriver;
-	let originalBranch: string | undefined;
-	let gitExistedBefore: boolean;
+    let bench: Workbench;
+    let treeScans: CustomTreeSection;
+    let driver: WebDriver;
+    let originalBranch: string | undefined;
+    let gitExistedBefore: boolean;
 
-	before(async function () {
-		this.timeout(300000);
+    before(async function () {
+        this.timeout(300000);
 
 		const branchName = "branch-not-exist-in-cx";
 		// check if git repository exists
@@ -111,10 +106,10 @@ describe("Using a local branch if Git exists", () => {
 		}
 		switchToBranch(branchName);
 
-		bench = new Workbench();
-		driver = VSBrowser.instance.driver;
-		await bench.executeCommand(CX_SELECT_SCAN);
-	});
+        bench = new Workbench();
+        driver = VSBrowser.instance.driver;
+        await bench.executeCommand(CX_SELECT_SCAN);
+    });
 
 
 	after(async function () {

--- a/src/test/10.localBranch.test.ts
+++ b/src/test/10.localBranch.test.ts
@@ -168,9 +168,10 @@ describe("Using a local branch if Git exists", () => {
         let firstNotification = await waitForNotificationWithTimeout(5000)
         let message = await firstNotification?.getMessage();
         if (message === messages.scanProjectNotMatch) {
-            await firstNotification?.getActions()[0].click();
-            const resultsNotifications = await new Workbench().getNotifications();
-            firstNotification = resultsNotifications[0];
+            let actions = await firstNotification?.getActions()
+            let action = await actions[0];
+            await action.click();
+            firstNotification = await waitForNotificationWithTimeout(5000);
         }
         expect(firstNotification).is.not.undefined;
 

--- a/src/test/10.localBranch.test.ts
+++ b/src/test/10.localBranch.test.ts
@@ -62,27 +62,7 @@ async function selectItem(text) {
     return item;
 }
 
-async function waitForNotificationWithTimeout(timeout) {
-	let firstNotification;
-	let isTimeout = false;
 
-	const timer = setTimeout(() => {
-		isTimeout = true;
-	}, timeout);
-
-	while (!firstNotification) {
-		if (isTimeout) {
-			break;
-		}
-		const resultsNotifications = await new Workbench().getNotifications();
-		firstNotification = resultsNotifications[0];
-
-		await sleep(100);
-	}
-
-	clearTimeout(timer);
-	return firstNotification;
-}
 
 describe("Using a local branch if Git exists", () => {
     let bench: Workbench;

--- a/src/test/10.localBranch.test.ts
+++ b/src/test/10.localBranch.test.ts
@@ -8,7 +8,7 @@ import {
 } from "vscode-extension-tester";
 import { messages } from "../utils/common/messages";
 import {expect} from "chai";
-import {getQuickPickSelector, initialize, sleep, waitForNotificationWithTimeout} from "./utils/utils";
+import {getQuickPickSelector, initialize, retryTest, sleep, waitForNotificationWithTimeout} from "./utils/utils";
 import {
     BRANCH_KEY_TREE,
     CX_CLEAR,
@@ -22,25 +22,6 @@ import { CX_TEST_SCAN_PROJECT_NAME } from "./utils/envs";
 import { constants } from "../utils/common/constants";
 import { execSync } from "child_process";
 import * as fs from "fs";
-
-
-function retryTest(testFn, retries = 3) {
-    return async function () {
-        let lastError;
-        for (let attempt = 1; attempt <= retries; attempt++) {
-            try {
-                await testFn();
-                return;
-            } catch (error) {
-                lastError = error;
-                console.warn(`Retrying test... Attempt ${attempt} of ${retries}`);
-                if (attempt === retries) {
-                    throw lastError;
-                }
-            }
-        }
-    };
-}
 
 function switchToBranch(branchName: string) {
 	try {

--- a/src/test/6.scan.test.ts
+++ b/src/test/6.scan.test.ts
@@ -41,7 +41,9 @@ describe("Scan from IDE", () => {
         let firstNotification = resultsNotifications[0];
         let message = await firstNotification?.getMessage();
         expect(message).to.equal(messages.scanProjectNotMatch);
-        await firstNotification?.getActions()[1].click();
+        let actions = await firstNotification?.getActions()
+        let action = await actions[1];
+        await action.click();
     });
 
     it("should run scan from IDE", async function () {

--- a/src/test/6.scan.test.ts
+++ b/src/test/6.scan.test.ts
@@ -11,6 +11,7 @@ import {SCAN_ID} from "./utils/envs";
 import {messages} from "../utils/common/messages";
 import { fail } from "assert";
 import {initialize, waitForNotificationWithTimeout} from "./utils/utils";
+import {expect} from "chai";
 
 
 
@@ -53,7 +54,8 @@ describe("Scan from IDE", () => {
             let action = await actions[0];
             await action.click();
         }
-        await waitForNotificationWithTimeout(5000);
+        firstNotification = await waitForNotificationWithTimeout(5000);
+        expect(firstNotification).to.be.undefined;
     });
 
     it("should get wrong project notification", async function () {

--- a/src/test/6.scan.test.ts
+++ b/src/test/6.scan.test.ts
@@ -62,7 +62,7 @@ describe("Scan from IDE", () => {
     let firstNotification = resultsNotifications[0];
     let message = await firstNotification?.getMessage();
     if (message === messages.scanProjectNotMatch) {
-        await await firstNotification?.getActions()[0].click();
+        await firstNotification?.getActions()[0].click();
         resultsNotifications = await new Workbench().getNotifications();
         firstNotification = resultsNotifications[0];
         expect(firstNotification).is.not.undefined;

--- a/src/test/6.scan.test.ts
+++ b/src/test/6.scan.test.ts
@@ -1,72 +1,98 @@
 import {
-  CustomTreeSection,
-  InputBox,
-  VSBrowser,
-  WebDriver,
-  Workbench,
+    CustomTreeSection,
+    InputBox,
+    VSBrowser,
+    WebDriver,
+    Workbench,
 } from "vscode-extension-tester";
-import { expect } from "chai";
-import { initialize } from "./utils/utils";
-import { CX_CLEAR, CX_LOOK_SCAN, VS_OPEN_FOLDER, SCAN_KEY_TREE_LABEL } from "./utils/constants";
-import { waitByLinkText } from "./utils/waiters";
-import { SCAN_ID } from "./utils/envs";
-import { messages } from "../utils/common/messages";
+import {expect} from "chai";
+import {initialize} from "./utils/utils";
+import {CX_CLEAR, CX_LOOK_SCAN, VS_OPEN_FOLDER, SCAN_KEY_TREE_LABEL} from "./utils/constants";
+import {waitByLinkText} from "./utils/waiters";
+import {SCAN_ID} from "./utils/envs";
+import {messages} from "../utils/common/messages";
 
 
 describe("Scan from IDE", () => {
-  let bench: Workbench;
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  let treeScans: CustomTreeSection;
-  let driver: WebDriver;
+    let bench: Workbench;
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    let treeScans: CustomTreeSection;
+    let driver: WebDriver;
 
-  before(async function () {
-    this.timeout(100000);
-    bench = new Workbench();
-    driver = VSBrowser.instance.driver;
-    treeScans = await initialize();
-    await bench.executeCommand(VS_OPEN_FOLDER);
-  });
+    before(async function () {
+        this.timeout(100000);
+        bench = new Workbench();
+        driver = VSBrowser.instance.driver;
+        treeScans = await initialize();
+        await bench.executeCommand(VS_OPEN_FOLDER);
+    });
 
-  after(async () => {
-    await bench.executeCommand(CX_CLEAR);
-  });
+    after(async () => {
+        await bench.executeCommand(CX_CLEAR);
+    });
 
-  it("should get wrong project notification", async function () {
-    await bench.executeCommand(CX_LOOK_SCAN);
-    const input = await InputBox.create();
-    await input.setText(SCAN_ID);
-    await input.confirm();
-    await bench.executeCommand("ast-results.createScan");
-    let resultsNotifications = await new Workbench().getNotifications();
-    let firstNotification = resultsNotifications[0];
-    let message = await firstNotification?.getMessage();
-    expect(message).to.equal(messages.scanProjectNotMatch);
-    await firstNotification?.getActions()[1].click();
-  });
+    it("should get wrong project notification", async function () {
+        await bench.executeCommand(CX_LOOK_SCAN);
+        const input = await InputBox.create();
+        await input.setText(SCAN_ID);
+        await input.confirm();
+        await bench.executeCommand("ast-results.createScan");
+        let resultsNotifications = await new Workbench().getNotifications();
+        let firstNotification = resultsNotifications[0];
+        let message = await firstNotification?.getMessage();
+        expect(message).to.equal(messages.scanProjectNotMatch);
+        await firstNotification?.getActions()[1].click();
+    });
 
-  it("should run scan from IDE", async function () {
-    const treeScan = await initialize();
-    await bench.executeCommand(CX_LOOK_SCAN);
-    const input = await InputBox.create();
-    await input.setText(SCAN_ID);
-    await input.confirm();
-    await waitByLinkText(driver, SCAN_KEY_TREE_LABEL, 5000);
-    let scan = await treeScan?.findItem(SCAN_KEY_TREE_LABEL);
-    while (scan === undefined) {
-      scan = await treeScan?.findItem(SCAN_KEY_TREE_LABEL);
-    }
-    // click play button(or initiate scan with command)
-    await bench.executeCommand("ast-results.createScan");
+    it("should run scan from IDE", async function () {
+        const treeScan = await initialize();
+        await bench.executeCommand(CX_LOOK_SCAN);
+        const input = await InputBox.create();
+        await input.setText(SCAN_ID);
+        await input.confirm();
+        await waitByLinkText(driver, SCAN_KEY_TREE_LABEL, 5000);
+        let scan = await treeScan?.findItem(SCAN_KEY_TREE_LABEL);
+        while (scan === undefined) {
+            scan = await treeScan?.findItem(SCAN_KEY_TREE_LABEL);
+        }
+        // click play button(or initiate scan with command)
+        await bench.executeCommand("ast-results.createScan");
 
-    let resultsNotifications = await new Workbench().getNotifications();
-    let firstNotification = resultsNotifications[0];
-    let message = await firstNotification?.getMessage();
-    if (message === messages.scanProjectNotMatch) {
-        await firstNotification?.getActions()[0].click();
-        resultsNotifications = await new Workbench().getNotifications();
-        firstNotification = resultsNotifications[0];
+        let resultsNotifications = await new Workbench().getNotifications();
+        let firstNotification = resultsNotifications[0];
+        let message = await firstNotification?.getMessage();
+        if (message === messages.scanProjectNotMatch) {
+            let actions = await firstNotification?.getActions()
+            let action = await actions[0];
+            await action.click();
+            firstNotification = await waitForNotificationWithTimeout(5000);
+        }
         expect(firstNotification).is.not.undefined;
-    }
-    expect(firstNotification).is.not.undefined;
-  });
+    });
 });
+
+async function waitForNotificationWithTimeout(timeout) {
+    let firstNotification;
+    let isTimeout = false;
+
+    const timer = setTimeout(() => {
+        isTimeout = true;
+    }, timeout);
+
+    while (!firstNotification) {
+        if (isTimeout) {
+            break;
+        }
+        const resultsNotifications = await new Workbench().getNotifications();
+        firstNotification = resultsNotifications[0];
+
+        await sleep(100);
+    }
+
+    clearTimeout(timer);
+    return firstNotification;
+}
+
+async function sleep(ms: number) {
+    return await new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/src/test/6.scan.test.ts
+++ b/src/test/6.scan.test.ts
@@ -10,7 +10,7 @@ import {waitByLinkText} from "./utils/waiters";
 import {SCAN_ID} from "./utils/envs";
 import {messages} from "../utils/common/messages";
 import { fail } from "assert";
-import {initialize, waitForNotificationWithTimeout} from "./utils/utils";
+import {initialize, retryTest, waitForNotificationWithTimeout} from "./utils/utils";
 import {expect} from "chai";
 
 
@@ -33,7 +33,7 @@ describe("Scan from IDE", () => {
         await bench.executeCommand(CX_CLEAR);
     });
 
-    it("should run scan from IDE", async function () {
+    it("should run scan from IDE", retryTest(async function () {
         const treeScan = await initialize();
         await bench.executeCommand(CX_LOOK_SCAN);
         const input = await InputBox.create();
@@ -55,10 +55,10 @@ describe("Scan from IDE", () => {
             await action.click();
         }
         firstNotification = await waitForNotificationWithTimeout(5000);
-        expect(firstNotification).to.be.undefined;
-    });
+        expect(firstNotification).to.not.be.undefined;
+    }));
 
-    it("should get wrong project notification", async function () {
+    it("should get wrong project notification", retryTest(async function () {
         const treeScan = await initialize();
         await bench.executeCommand(CX_LOOK_SCAN);
         const input = await InputBox.create();
@@ -81,5 +81,5 @@ describe("Scan from IDE", () => {
           fail("Should get wrong project notification");
         }
 
-    });
+    }));
 });

--- a/src/test/6.scan.test.ts
+++ b/src/test/6.scan.test.ts
@@ -57,17 +57,14 @@ describe("Scan from IDE", () => {
         }
         // click play button(or initiate scan with command)
         await bench.executeCommand("ast-results.createScan");
-
-        let resultsNotifications = await new Workbench().getNotifications();
-        let firstNotification = resultsNotifications[0];
+        
+        let firstNotification = await waitForNotificationWithTimeout(5000)
         let message = await firstNotification?.getMessage();
         if (message === messages.scanProjectNotMatch) {
             let actions = await firstNotification?.getActions()
-            let action = await actions[0];
+            let action = await actions[1];
             await action.click();
-            firstNotification = await waitForNotificationWithTimeout(5000);
         }
-        expect(firstNotification).is.not.undefined;
     });
 });
 

--- a/src/test/6.scan.test.ts
+++ b/src/test/6.scan.test.ts
@@ -10,6 +10,8 @@ import { initialize } from "./utils/utils";
 import { CX_CLEAR, CX_LOOK_SCAN, VS_OPEN_FOLDER, SCAN_KEY_TREE_LABEL } from "./utils/constants";
 import { waitByLinkText } from "./utils/waiters";
 import { SCAN_ID } from "./utils/envs";
+import { messages } from "../utils/common/messages";
+
 
 describe("Scan from IDE", () => {
   let bench: Workbench;
@@ -29,6 +31,18 @@ describe("Scan from IDE", () => {
     await bench.executeCommand(CX_CLEAR);
   });
 
+  it("should get wrong project notification", async function () {
+    await bench.executeCommand(CX_LOOK_SCAN);
+    const input = await InputBox.create();
+    await input.setText(SCAN_ID);
+    await input.confirm();
+    let resultsNotifications = await new Workbench().getNotifications();
+    let firstNotification = resultsNotifications[0];
+    let message = await firstNotification?.getMessage();
+    expect(message).to.equal(messages.scanProjectNotMatch);
+    await firstNotification?.getActions()[1].click();
+  });
+
   it("should run scan from IDE", async function () {
     const treeScan = await initialize();
     await bench.executeCommand(CX_LOOK_SCAN);
@@ -43,8 +57,15 @@ describe("Scan from IDE", () => {
     // click play button(or initiate scan with command)
     await bench.executeCommand("ast-results.createScan");
 
-    const resultsNotifications = await new Workbench().getNotifications();
-    const firstNotification = resultsNotifications[0];
+    let resultsNotifications = await new Workbench().getNotifications();
+    let firstNotification = resultsNotifications[0];
+    let message = await firstNotification?.getMessage();
+    if (message === messages.scanProjectNotMatch) {
+        await await firstNotification?.getActions()[0].click();
+        resultsNotifications = await new Workbench().getNotifications();
+        firstNotification = resultsNotifications[0];
+        expect(firstNotification).is.not.undefined;
+    }
     expect(firstNotification).is.not.undefined;
   });
 });

--- a/src/test/6.scan.test.ts
+++ b/src/test/6.scan.test.ts
@@ -5,13 +5,13 @@ import {
     WebDriver,
     Workbench,
 } from "vscode-extension-tester";
-import {expect} from "chai";
-import {initialize} from "./utils/utils";
 import {CX_CLEAR, CX_LOOK_SCAN, VS_OPEN_FOLDER, SCAN_KEY_TREE_LABEL} from "./utils/constants";
 import {waitByLinkText} from "./utils/waiters";
 import {SCAN_ID} from "./utils/envs";
 import {messages} from "../utils/common/messages";
 import { fail } from "assert";
+import {initialize, waitForNotificationWithTimeout} from "./utils/utils";
+
 
 
 describe("Scan from IDE", () => {
@@ -81,29 +81,3 @@ describe("Scan from IDE", () => {
 
     });
 });
-
-async function waitForNotificationWithTimeout(timeout) {
-    let firstNotification;
-    let isTimeout = false;
-
-    const timer = setTimeout(() => {
-        isTimeout = true;
-    }, timeout);
-
-    while (!firstNotification) {
-        if (isTimeout) {
-            break;
-        }
-        const resultsNotifications = await new Workbench().getNotifications();
-        firstNotification = resultsNotifications[0];
-
-        await sleep(100);
-    }
-
-    clearTimeout(timer);
-    return firstNotification;
-}
-
-async function sleep(ms: number) {
-    return await new Promise(resolve => setTimeout(resolve, ms));
-}

--- a/src/test/6.scan.test.ts
+++ b/src/test/6.scan.test.ts
@@ -36,6 +36,7 @@ describe("Scan from IDE", () => {
     const input = await InputBox.create();
     await input.setText(SCAN_ID);
     await input.confirm();
+    await bench.executeCommand("ast-results.createScan");
     let resultsNotifications = await new Workbench().getNotifications();
     let firstNotification = resultsNotifications[0];
     let message = await firstNotification?.getMessage();

--- a/src/test/6.scan.test.ts
+++ b/src/test/6.scan.test.ts
@@ -57,10 +57,17 @@ describe("Scan from IDE", () => {
     });
 
     it("should get wrong project notification", async function () {
+        const treeScan = await initialize();
         await bench.executeCommand(CX_LOOK_SCAN);
         const input = await InputBox.create();
         await input.setText(SCAN_ID);
         await input.confirm();
+        await waitByLinkText(driver, SCAN_KEY_TREE_LABEL, 5000);
+        let scan = await treeScan?.findItem(SCAN_KEY_TREE_LABEL);
+        while (scan === undefined) {
+            scan = await treeScan?.findItem(SCAN_KEY_TREE_LABEL);
+        }
+        // click play button(or initiate scan with command)
         await bench.executeCommand("ast-results.createScan");
         let firstNotification = await waitForNotificationWithTimeout(5000)
         let message = await firstNotification?.getMessage();

--- a/src/test/utils/utils.ts
+++ b/src/test/utils/utils.ts
@@ -150,5 +150,23 @@ export async function sleep(ms: number) {
   return await new Promise(resolve => setTimeout(resolve, ms));
 }
 
+export function retryTest(testFn, retries = 3) {
+  return async function () {
+    let lastError;
+    for (let attempt = 1; attempt <= retries; attempt++) {
+      try {
+        await testFn();
+        return;
+      } catch (error) {
+        lastError = error;
+        console.warn(`Retrying test... Attempt ${attempt} of ${retries}`);
+        if (attempt === retries) {
+          throw lastError;
+        }
+      }
+    }
+  };
+}
+
 export const delay = (ms: number | undefined) =>
   new Promise((res) => setTimeout(res, ms));

--- a/src/test/utils/utils.ts
+++ b/src/test/utils/utils.ts
@@ -4,7 +4,7 @@ import {
   CustomTreeSection,
   SideBarView,
   InputBox,
-  WebView,
+  WebView, Workbench,
 } from "vscode-extension-tester";
 import { FIVE_SECONDS, THIRTY_SECONDS, THREE_SECONDS } from "./constants";
 
@@ -122,6 +122,32 @@ export async function validateRootNode(scan: any): Promise<[number, any]> {
   let engines = await scan?.getChildren();
   let size = engines?.length;
   return [size, engines];
+}
+
+export async function waitForNotificationWithTimeout(timeout) {
+  let firstNotification;
+  let isTimeout = false;
+
+  const timer = setTimeout(() => {
+    isTimeout = true;
+  }, timeout);
+
+  while (!firstNotification) {
+    if (isTimeout) {
+      break;
+    }
+    const resultsNotifications = await new Workbench().getNotifications();
+    firstNotification = resultsNotifications[0];
+
+    await sleep(100);
+  }
+
+  clearTimeout(timer);
+  return firstNotification;
+}
+
+export async function sleep(ms: number) {
+  return await new Promise(resolve => setTimeout(resolve, ms));
 }
 
 export const delay = (ms: number | undefined) =>

--- a/src/utils/common/messages.ts
+++ b/src/utils/common/messages.ts
@@ -14,8 +14,11 @@ export const messages = {
   scanProjectsNotMatch:
     "Project in workspace doesn't match the selected Checkmarx project. Do you want to scan anyway?",
   scanBranchMatch: "Branch match the view branch. Initiating scan...",
+  scanProjectMatch: "Project match the view project. Initiating scan...",
   scanBranchNotMatch:
     "Git branch doesn't match the selected Checkmarx branch. Do you want to scan anyway?",
+  scanProjectNotMatch:
+      "Git project doesn't match the selected Checkmarx project. Do you want to scan anyway?",
   scanCheckStart:
     "Scan initiation started. Checking if scan is eligible to be initiated...",
   scanCompletedLoadResults: (status, scanID) =>

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -163,17 +163,17 @@ export async function getActiveRepository(): Promise<Repository | undefined> {
   return gitAPI.repositories[0]; // Default to the first repository
 }
 
-export async function getRepositoryFullName(): Promise<string | void> {
+export async function getRepositoryFullName(): Promise<string | undefined> {
   const activeRepo = await getActiveRepository();
   if (!activeRepo) {
-    return;
+    return undefined;
   }
 
   const remote = activeRepo.state.remotes.find((r) => r.name === "origin") || activeRepo.state.remotes[0];
   const remoteURL = remote?.fetchUrl;
 
   if (!remoteURL) {
-    return;
+    return undefined;
   }
 
   return extractRepoFullName(remoteURL)

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -176,11 +176,7 @@ export async function getRepositoryFullName(): Promise<string | void> {
     return;
   }
 
-  const fullName = extractRepoFullName(remoteURL);
-  if (fullName) {
-    return fullName;
-  } 
-  return;
+  return extractRepoFullName(remoteURL)
 }
 
 export async function getResultsJson() {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -183,26 +183,6 @@ export async function getRepositoryFullName(): Promise<string | void> {
   return;
 }
 
-
-export async function getRepositoryName() {
-  const gitAPI = await getGitAPIRepository();
-  if (!gitAPI) {
-    vscode.window.showErrorMessage("Git extension is not available.");
-    return;
-  }
-
-  const repositories  = gitAPI.repositories;
-  if (repositories.length === 0) {
-    return;
-  }
-
-  const firstRepo = repositories[0];
-  const repoPath = firstRepo.rootUri.fsPath;
-  const repoName = repoPath.substring(repoPath.lastIndexOf("/") + 1);
-
-  return repoName;
-}
-
 export async function getResultsJson() {
   const resultJsonPath = getResultsFilePath();
   if (fs.existsSync(resultJsonPath)) {

--- a/src/views/resultsView/createScanProvider.ts
+++ b/src/views/resultsView/createScanProvider.ts
@@ -158,14 +158,14 @@ export async function createScan(
   updateState(context, constants.scanCreatePrepKey, { id: true, name: "", displayScanId: undefined, scanDatetime: undefined });
   updateStatusBarItem(constants.scanCreate, true, statusBarItem);
 
+  if (!(await doesProjectMatch(context, logs))) {
+    updateStatusBarItem(constants.scanWaiting, false, statusBarItem);
+    updateState(context, constants.scanCreatePrepKey, { id: false, name: "", displayScanId: undefined, scanDatetime: undefined });
+    return;
+  }
+
   if (getFromState(context, constants.branchIdKey).id !== constants.localBranch) {
     updateStatusBarItem(constants.scanCreateVerifyBranch, true, statusBarItem);
-
-    if (!(await doesProjectMatch(context, logs))) {
-      updateStatusBarItem(constants.scanWaiting, false, statusBarItem);
-      updateState(context, constants.scanCreatePrepKey, { id: false, name: "", displayScanId: undefined, scanDatetime: undefined });
-      return;
-    }
 
     if (!(await doesBranchMatch(context, logs))) {
       updateStatusBarItem(constants.scanWaiting, false, statusBarItem);

--- a/src/views/resultsView/createScanProvider.ts
+++ b/src/views/resultsView/createScanProvider.ts
@@ -139,9 +139,9 @@ async function doesBranchMatch(context: vscode.ExtensionContext, logs: Logs) {
 
 async function doesProjectMatch(context: vscode.ExtensionContext, logs: Logs) {
   const projectForScan: Item = context.workspaceState.get(constants.projectIdKey);
-  const projectName = projectForScan.name.match(new RegExp(`${constants.projectLabel}\\s*(.+)`))[1].trim();
+  const projectName = projectForScan?.name.match(new RegExp(`${constants.projectLabel}\\s*(.+)`))[1].trim();
   const workspaceProject = await getRepositoryFullName();
-  if (projectName === workspaceProject) {
+  if (projectForScan && projectName && projectName === workspaceProject) {
     logs.info(messages.scanProjectMatch);
     return true;
   } else {

--- a/src/views/resultsView/createScanProvider.ts
+++ b/src/views/resultsView/createScanProvider.ts
@@ -9,7 +9,7 @@ import {
   constants
 } from "../../utils/common/constants";
 import { getFromState, Item, updateState } from "../../utils/common/globalState";
-import { getGitBranchName, getResultsJson, updateStatusBarItem } from "../../utils/utils";
+import { getRepositoryFullName, getGitBranchName, getResultsJson, updateStatusBarItem } from "../../utils/utils";
 import { messages } from "../../utils/common/messages";
 import { commands } from "../../utils/common/commands";
 import { loadScanId } from "../../utils/pickers/pickers";
@@ -137,6 +137,18 @@ async function doesBranchMatch(context: vscode.ExtensionContext, logs: Logs) {
   }
 }
 
+async function doesProjectMatch(context: vscode.ExtensionContext, logs: Logs) {
+  const projectForScan: Item = context.workspaceState.get(constants.projectIdKey);
+  const projectName = projectForScan.name.match(new RegExp(`${constants.projectLabel}\\s*(.+)`))[1].trim();
+  const workspaceProject = await getRepositoryFullName();
+  if (projectName === workspaceProject) {
+    logs.info(messages.scanProjectMatch);
+    return true;
+  } else {
+    return await getUserInput(messages.scanProjectNotMatch);
+  }
+}
+
 export async function createScan(
   context: vscode.ExtensionContext,
   statusBarItem: vscode.StatusBarItem,
@@ -148,6 +160,13 @@ export async function createScan(
 
   if (getFromState(context, constants.branchIdKey).id !== constants.localBranch) {
     updateStatusBarItem(constants.scanCreateVerifyBranch, true, statusBarItem);
+
+    if (!(await doesProjectMatch(context, logs))) {
+      updateStatusBarItem(constants.scanWaiting, false, statusBarItem);
+      updateState(context, constants.scanCreatePrepKey, { id: false, name: "", displayScanId: undefined, scanDatetime: undefined });
+      return;
+    }
+
     if (!(await doesBranchMatch(context, logs))) {
       updateStatusBarItem(constants.scanWaiting, false, statusBarItem);
       updateState(context, constants.scanCreatePrepKey, { id: false, name: "", displayScanId: undefined, scanDatetime: undefined });


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](../docs/code_of_conduct.md). Please see the [contributing guidelines](../docs/contributing.md) for how to create and submit a high-quality PR for this repo.

### Description

> Added a warning to the user when he want to run a scan in case that local project name is difference than the CX project

### References

> https://checkmarx.atlassian.net/browse/AST-78313

### Testing

> Added UI test

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR (if applicable).
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used