### PR TITLE
Display CWE reference link in Learn More section (AST-95343)

### DIFF
--- a/media/view.js
+++ b/media/view.js
@@ -364,9 +364,21 @@
 				html += riskSection(description.risk);
 				html += causeSection(description.cause);
 				html += recommendationSection(description.generalRecommendations);
+				// Dynamically add CWE link if available
+            if (result.cweId) {
+                html += `
+                    <div class="learn-section">
+                        <p>
+                            <strong>Learn more about this vulnerability:</strong>
+                            <a href="https://cwe.mitre.org/data/definitions/${result.cweId}.html" target="_blank" rel="noopener noreferrer">
+                                CWE-${result.cweId}
+                            </a>
+                        </p>
+                    </div>
+                `;
 			}
 		}
-		else {
+	} else {
 			html +=
 				`
 				<div class="history-container">


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](../docs/code_of_conduct.md). Please see the [contributing guidelines](../docs/contributing.md) for how to create and submit a high-quality PR for this repo.

### Description

>This PR adds a CWE reference link to the "Learn More" section for vulnerabilities.
If a CWE ID is available in the scan result, the UI now displays a friendly label (e.g., "CWE-36") as a clickable link.
The link text is user-friendly, while the actual link points to the official CWE page for more details.
The phrase "Learn more about this vulnerability:" is included for clarity and user guidance.

### References

> Include supporting link to GitHub Issue/PR number

### Testing

> Manually verified that vulnerabilities with a cweId display the new CWE reference link in the Learn More section.
Confirmed that the link text is "CWE-XX" and clicking it opens the correct CWE page in a new tab.
Verified that vulnerabilities without a cweId do not show the CWE reference section.
Existing functionality and other sections remain unaffected.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used
![VScode_CweLink](https://github.com/user-attachments/assets/ea049d59-1700-4a78-ac36-60f4c7dc3d54)
