### PR TITLE
Displayed additiona traits and Risk score in ASPM results UI (AST-93137)

### DIFF
--- a/media/riskManagement.js
+++ b/media/riskManagement.js
@@ -406,7 +406,6 @@
       );
 
         resultElement.addEventListener("click", () => {
-          debugger;
           vscode.postMessage({
             command: "openVulnerabilityDetails",
             result: result,

--- a/media/riskManagement.js
+++ b/media/riskManagement.js
@@ -406,6 +406,7 @@
       );
 
         resultElement.addEventListener("click", () => {
+          debugger;
           vscode.postMessage({
             command: "openVulnerabilityDetails",
             result: result,

--- a/media/sca.css
+++ b/media/sca.css
@@ -33,9 +33,10 @@
 	justify-self: left;
 }
 .header-risk-score {
-	font-size: 1em;
+	font-size: 1.2em;
+	border-radius: 4px;
     font-weight: bold;
-	margin-left: 1%;
+	margin-left: 0.5%;
 }
 
 .critical-risk {

--- a/media/sca.css
+++ b/media/sca.css
@@ -32,6 +32,31 @@
 	flex: 40;
 	justify-self: left;
 }
+.header-risk-score {
+	font-size: 1em;
+    font-weight: bold;
+	margin-left: 1%;
+}
+
+.critical-risk {
+  color: #bb2a31d9;
+  border: 1px solid #bb2a31d9;
+}
+
+.high-risk {
+  color: #f8788fe5;
+  border: 1px solid #f8788fe5;
+}
+
+.medium-risk {
+  color: #e7984999;
+  border: 1px solid #e7984999;
+}
+
+.low-risk {
+  color: #419128;
+  border: 1px solid #419128;
+}
 
 .body-sca {
 	height: 100%;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "ast-results",
       "version": "2.34.0",
       "dependencies": {
-        "@checkmarxdev/ast-cli-javascript-wrapper": "0.0.135",
+        "@checkmarxdev/ast-cli-javascript-wrapper": "0.0.136-riskscore.0",
         "@popperjs/core": "^2.11.8",
         "@vscode/codicons": "^0.0.36",
         "axios": "^1.8.3",
@@ -547,9 +547,9 @@
     },
     "node_modules/@checkmarxdev/ast-cli-javascript-wrapper": {
       "name": "@CheckmarxDev/ast-cli-javascript-wrapper",
-      "version": "0.0.135",
-      "resolved": "https://npm.pkg.github.com/download/@CheckmarxDev/ast-cli-javascript-wrapper/0.0.135/7a7e303ca564ff7f45a8e38c0cc79a30b3f35d77",
-      "integrity": "sha512-4Li6FAUShpTIcOa3hi/ucLJD/s90okOHN480fFsc1CWB8K/E7Mv6q9xu+avSVFKJn9GxuhB0GLZhUMx97ENuDg==",
+      "version": "0.0.136-riskscore.0",
+      "resolved": "https://npm.pkg.github.com/download/@CheckmarxDev/ast-cli-javascript-wrapper/0.0.136-riskscore.0/ddcf46e666297aee137536556e0d9a93d9a17188",
+      "integrity": "sha512-KVdVko8lu4/F9wYDtAyoiWhUqtjcxAVhqXmVjfqtpZcWXXPLU6LrEMAe4wyMmuCED3xVEIv3tp1bFBYGTqS0AQ==",
       "license": "ISC",
       "dependencies": {
         "log4js": "^6.9.1"

--- a/package.json
+++ b/package.json
@@ -980,6 +980,7 @@
     "@popperjs/core": "^2.11.8",
     "@vscode/codicons": "^0.0.36",
     "axios": "^1.8.3",
+    "@checkmarxdev/ast-cli-javascript-wrapper": "0.0.136-riskscore.0",
     "copyfiles": "2.4.1",
     "dotenv": "^16.4.7",
     "eslint-config-prettier": "^9.1.0",

--- a/src/models/results.ts
+++ b/src/models/results.ts
@@ -721,7 +721,7 @@ export class AstResult extends CxResult {
       </div>
             `
         }
-    <div class="card" style="border:0">
+    <div class="card" >
       <p class="header-content">
         References
       </p>
@@ -729,6 +729,37 @@ export class AstResult extends CxResult {
         ${result.scaReferences()}
       </div>
     </div>
+    <div class="card" style="border:0">
+      <div style="display: inline-block;position: relative;">
+          <p class="header-content">
+            Additional trait
+          </p>
+      </div>
+      <div class="card-content">
+            <table class="package-table" id="package-table-${0 + 1}">
+              <tbody>
+              <tr>
+                  <td>
+                    <div>
+                      <div style="display: inline-block">
+                        Suspected Malware
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    <div>
+                      <div style="display: inline-block">
+                        Exploitable Path
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+      </div>
+  </div>
   </div>
       `
           : `

--- a/src/models/results.ts
+++ b/src/models/results.ts
@@ -60,8 +60,8 @@ export class AstResult extends CxResult {
       result.data.queryName
         ? result.data.queryName
         : result.id
-        ? result.id
-        : result.vulnerabilityDetails.cveName,
+          ? result.id
+          : result.vulnerabilityDetails.cveName,
       result.id,
       result.status,
       result.alternateId,
@@ -87,10 +87,10 @@ export class AstResult extends CxResult {
     this.label = result.data.queryName
       ? result.data.queryName
       : this.formatFilenameLine(result)
-      ? this.formatFilenameLine(result)
-      : result.id
-      ? result.id
-      : result.vulnerabilityDetails.cveName;
+        ? this.formatFilenameLine(result)
+        : result.id
+          ? result.id
+          : result.vulnerabilityDetails.cveName;
     this.severity = result.severity;
     this.status = result.status;
     this.language = result.data.languageName;
@@ -138,13 +138,11 @@ export class AstResult extends CxResult {
         this.fileName && this.fileName.includes("/")
           ? this.fileName.slice(this.fileName.lastIndexOf("/"))
           : "";
-      this.label += ` (${
-        shortFilename.length && shortFilename.length > 0
-          ? shortFilename
-          : this.fileName
-      }${
-        result.data.nodes[0].line > 0 ? ":" + result.data.nodes[0].line : ""
-      })`;
+      this.label += ` (${shortFilename.length && shortFilename.length > 0
+        ? shortFilename
+        : this.fileName
+        }${result.data.nodes[0].line > 0 ? ":" + result.data.nodes[0].line : ""
+        })`;
     } else if (result.data.fileName) {
       //Relevant for scs  , because this engine  have the filename inside result.data
       this.fileName = result.data.fileName;
@@ -152,11 +150,10 @@ export class AstResult extends CxResult {
         this.fileName && this.fileName.includes("/")
           ? this.fileName.slice(this.fileName.lastIndexOf("/"))
           : "";
-      this.label += ` (${
-        shortFilename.length && shortFilename.length > 0
-          ? shortFilename
-          : this.fileName
-      }${result.data.line > 0 ? ":" + result.data.line : ""})`;
+      this.label += ` (${shortFilename.length && shortFilename.length > 0
+        ? shortFilename
+        : this.fileName
+        }${result.data.line > 0 ? ":" + result.data.line : ""})`;
     }
 
     this.cweId = result.cweId || result.vulnerabilityDetails?.cweId;
@@ -331,9 +328,8 @@ export class AstResult extends CxResult {
               data-fullName="${this.kicsNode?.data.filename}" 
               data-length="${1}"
             >
-              ${this.getShortFilename(this.kicsNode?.data.filename)} [${
-      this.kicsNode?.data.line
-    }:${0}]
+              ${this.getShortFilename(this.kicsNode?.data.filename)} [${this.kicsNode?.data.line
+      }:${0}]
             </a>
           </td>
         </tr>
@@ -462,15 +458,13 @@ export class AstResult extends CxResult {
     this.scaNode.scaPackageData.dependencyPaths.forEach(
       (pathArray: any, indexDependency: number) => {
         if (indexDependency === 0) {
-          html += ` <div class="card-content" style="max-height:134px;overflow:scroll;margin-top:15px" id="locations-table-${
-            indexDependency + 1
-          }">
+          html += ` <div class="card-content" style="max-height:134px;overflow:scroll;margin-top:15px" id="locations-table-${indexDependency + 1
+            }">
         <table class="details-table" style="margin-left:28px;margin-top:15px;width:100%">
           <tbody>`;
         } else {
-          html += ` <div class="card-content" style="display:none;max-height:134px;overflow:scroll;margin-top:15px" id="locations-table-${
-            indexDependency + 1
-          }">
+          html += ` <div class="card-content" style="display:none;max-height:134px;overflow:scroll;margin-top:15px" id="locations-table-${indexDependency + 1
+            }">
         <table class="details-table" style="margin-left:28px;" >
           <tbody>`;
         }
@@ -498,11 +492,10 @@ export class AstResult extends CxResult {
                     >
                       ${location}
                     </a>
-                    ${
-                      this.scaNode.recommendedVersion &&
-                      this.scaNode.scaPackageData.supportsQuickFix === true &&
-                      this.scaNode.scaPackageData.dependencyPaths[0][0].name
-                        ? ` <img 
+                    ${this.scaNode.recommendedVersion &&
+                    this.scaNode.scaPackageData.supportsQuickFix === true &&
+                    this.scaNode.scaPackageData.dependencyPaths[0][0].name
+                    ? ` <img 
                           alt="icon" 
                           class="upgrade-small-icon" 
                           src="${scaUpgrade}"
@@ -510,8 +503,8 @@ export class AstResult extends CxResult {
                           data-package="${this.scaNode.scaPackageData.dependencyPaths[0][0].name}" 
                           data-file="${location}"
                         />`
-                        : ""
-                    }
+                    : ""
+                  }
                     ${index + 1 < path.locations.length ? `&nbsp;| &nbsp;` : ""}
                 `;
               });
@@ -539,19 +532,19 @@ export class AstResult extends CxResult {
   }
 
   public getHtmlAdditionaltrait(result: { traits: Record<string, string> }): string {
-      if (Object.keys(result.traits).length > 0) {
-        const rows = Object.entries(result.traits)
-          .map((value) =>
-            `<tr><td><div><div style="display: inline-block">${value[1]}</div></div></td></tr>`
-          )
-          .join("");
+    if (Object.keys(result.traits).length > 0) {
+      const rows = Object.entries(result.traits)
+        .map((value) =>
+          `<tr><td><div><div style="display: inline-block">${value[1]}</div></div></td></tr>`
+        )
+        .join("");
 
-        return `
+      return `
           <table class="package-table" id="package-table-1">
             <tbody>${rows}</tbody>
           </table>
         `;
-      }
+    }
 
     return `
       <div style="margin:15px 15px 15px 28px;"><p style="margin:25px;font-size:0.9em">
@@ -614,8 +607,7 @@ export class AstResult extends CxResult {
               <tbody>`;
         } else {
           html += `<div class="card-content">
-            <table class="package-table" style="display: none;" id="package-table-${
-              index + 1
+            <table class="package-table" style="display: none;" id="package-table-${index + 1
             }">
               <tbody>`;
         }
@@ -656,44 +648,39 @@ export class AstResult extends CxResult {
     <div class="left-content">
       <div class="card" style="border-top: 1px;border-top-style: solid;border-color: rgb(128, 128, 128,0.5) ;">
         <div class="description">
-          ${
-            result.descriptionHTML ? result.descriptionHTML : result.description
-          }
+          ${result.descriptionHTML ? result.descriptionHTML : result.description
+      }
         </div>
-        ${
-          type === "realtime"
-            ? `
+        ${type === "realtime"
+        ? `
         <div class="remediation-links-rows-realtime">
           <img class="remediation-links-rows-image" alt="icon" src="${scaUrl}" />
           <p class="remediation-links-text" id="${result.scaNode.scaPackageData.fixLink}">
             About this vulnerability
           </p>
         </div>`
-            : ""
-        }
+        : ""
+      }
       </div>
-      ${
-        result.scaNode.scaPackageData
-          ? `
+      ${result.scaNode.scaPackageData
+        ? `
       <div class="card">
-      ${
-        !type
+      ${!type
           ? `<p class="header-content">
       Remediation
     </p>`
           : ""
-      }
-    ${
-      !type
-        ? `
+        }
+    ${!type
+          ? `
     <div class="card-content">
         <div class="remediation-container">
           ${result.scaRemediation(result, scaUpgrade, scaUrl, type)}	
         </div>
       </div>
     `
-        : ""
-    }
+          : ""
+        }
     </div>
     <div class="card">
         <div style="display: inline-block;position: relative;">
@@ -701,32 +688,28 @@ export class AstResult extends CxResult {
           ${!type ? "Vulnerable Package Paths" : "Vulnerable Package"}
           </p>
         </div>
-        ${
-          result.scaNode.scaPackageData.dependencyPaths
-            ? `
+        ${result.scaNode.scaPackageData.dependencyPaths
+          ? `
         <div class="package-buttons-container">
           <button 
             class="package-back"
             id="package-back"
             data-current="1" 
-            data-total="${
-              result.scaNode.scaPackageData.dependencyPaths.length
-            }" 
+            data-total="${result.scaNode.scaPackageData.dependencyPaths.length
+          }" 
             data-previous="null"
             disabled
           >
           </button>
-          <p id="package-counter" class="package-counter-numbers">1/${
-            result.scaNode.scaPackageData.dependencyPaths.length
+          <p id="package-counter" class="package-counter-numbers">1/${result.scaNode.scaPackageData.dependencyPaths.length
           }</p>
           <button 
             class="package-next"
             data-current="1" 
-            ${
-              result.scaNode.scaPackageData.dependencyPaths.length === 1
-                ? "disabled"
-                : ""
-            }
+            ${result.scaNode.scaPackageData.dependencyPaths.length === 1
+            ? "disabled"
+            : ""
+          }
             data-total="${result.scaNode.scaPackageData.dependencyPaths.length}"
             id="package-next"
             data-previous="null"
@@ -735,7 +718,7 @@ export class AstResult extends CxResult {
         </div>
       ${result.scaPackages(scaUpgrade)}	
     </div>`
-            : !type
+          : !type
             ? `
           <div class="card-content">
             <p style="margin:25px;font-size:0.9em">
@@ -759,8 +742,8 @@ export class AstResult extends CxResult {
         ${result.scaReferences()}
       </div>
     </div>
-    ${result.traits !== undefined ? 
-        `<div class="card" style="border:0">
+    ${result.traits !== undefined ?
+          `<div class="card" style="border:0">
           <div style="display: inline-block;position: relative;">
               <p class="header-content">
                 Additional trait
@@ -770,10 +753,10 @@ export class AstResult extends CxResult {
                 ${result.getHtmlAdditionaltrait(result)}
           </div>
       </div>`
-      : ""} 
+          : ""} 
   </div>
       `
-          : `
+        : `
     <div class="card" style="border:0">
       <p style="margin:25px;font-size:0.9em"> 
         No more information available
@@ -783,9 +766,8 @@ export class AstResult extends CxResult {
     `
       }
   <div class="right-content">
-    ${
-      result.vulnerabilityDetails.cvss &&
-      result.vulnerabilityDetails.cvss.version
+    ${result.vulnerabilityDetails.cvss &&
+        result.vulnerabilityDetails.cvss.version
         ? `
       <div class="content">
         <div class="header-content-selected">
@@ -804,28 +786,26 @@ export class AstResult extends CxResult {
         </div>
       </div>
     `
-    }
+      }
     <div class="sca-details" style="border-bottom: 1px;border-bottom-style: solid;border-color: rgb(128, 128, 128,0.5);">
-      <div class="score-card" style="${
-        result.severity === "HIGH"
-          ? "border: 1px solid #D94B48"
-          : result.severity === "MEDIUM"
+      <div class="score-card" style="${result.severity === "HIGH"
+        ? "border: 1px solid #D94B48"
+        : result.severity === "MEDIUM"
           ? "border: 1px solid #F9AE4D"
           : result.severity === "LOW"
-          ? "border: 1px solid #029302"
-          : "border: 1px solid #87bed1"
+            ? "border: 1px solid #029302"
+            : "border: 1px solid #87bed1"
       }">
         <div class="left-${result.severity}">
           <p class="header-text">
             Score
           </p>
           <p>
-              ${
-                result.vulnerabilityDetails &&
-                result.vulnerabilityDetails.cvssScore
-                  ? result.vulnerabilityDetails.cvssScore.toFixed(1)
-                  : "N/A"
-              }
+              ${result.vulnerabilityDetails &&
+        result.vulnerabilityDetails.cvssScore
+        ? result.vulnerabilityDetails.cvssScore.toFixed(1)
+        : "N/A"
+      }
           </p>
         </div>
         <div class="right-${result.severity}">
@@ -846,12 +826,11 @@ export class AstResult extends CxResult {
             Attack Vector
           </p>
           <p class="info-cards-value">
-            ${
-              result.vulnerabilityDetails.cvss &&
-              result.vulnerabilityDetails.cvss.attackVector
-                ? result.vulnerabilityDetails.cvss.attackVector
-                : "No information"
-            }
+            ${result.vulnerabilityDetails.cvss &&
+        result.vulnerabilityDetails.cvss.attackVector
+        ? result.vulnerabilityDetails.cvss.attackVector
+        : "No information"
+      }
           </p>
         </div>
         <div class="info-cards-icon">
@@ -866,12 +845,11 @@ export class AstResult extends CxResult {
             Attack Complexity
           </p>
           <p class="info-cards-value">
-            ${
-              result.vulnerabilityDetails.cvss &&
-              result.vulnerabilityDetails.cvss.attackComplexity
-                ? result.vulnerabilityDetails.cvss.attackComplexity
-                : "No information"
-            }
+            ${result.vulnerabilityDetails.cvss &&
+        result.vulnerabilityDetails.cvss.attackComplexity
+        ? result.vulnerabilityDetails.cvss.attackComplexity
+        : "No information"
+      }
           </p>
         </div>
         <div class="info-cards-icon">
@@ -879,9 +857,8 @@ export class AstResult extends CxResult {
         </div>
       </div>
     </div>
-    ${
-      result.vulnerabilityDetails.cvss &&
-      result.vulnerabilityDetails.cvss.privilegesRequired
+    ${result.vulnerabilityDetails.cvss &&
+        result.vulnerabilityDetails.cvss.privilegesRequired
         ? `
       <div class="sca-details">
       <div class="info-cards">
@@ -890,11 +867,10 @@ export class AstResult extends CxResult {
             Privileges Required
           </p>
           <p class="info-cards-value">
-            ${
-              result.vulnerabilityDetails.cvss.privilegesRequired
-                ? result.vulnerabilityDetails.cvss.privilegesRequired
-                : "No information"
-            }
+            ${result.vulnerabilityDetails.cvss.privilegesRequired
+          ? result.vulnerabilityDetails.cvss.privilegesRequired
+          : "No information"
+        }
           </p>
         </div>
         <div class="info-cards-icon">
@@ -903,7 +879,7 @@ export class AstResult extends CxResult {
       </div>
     </div>`
         : ``
-    }
+      }
     <div class="sca-details">
       <div class="info-cards">
         <div class="info-cards-text">
@@ -911,12 +887,11 @@ export class AstResult extends CxResult {
             Confidentiality Impact
           </p>
           <p class="info-cards-value">
-            ${
-              result.vulnerabilityDetails.cvss &&
-              result.vulnerabilityDetails.cvss.confidentiality
-                ? result.vulnerabilityDetails.cvss.confidentiality
-                : "No information"
-            }
+            ${result.vulnerabilityDetails.cvss &&
+        result.vulnerabilityDetails.cvss.confidentiality
+        ? result.vulnerabilityDetails.cvss.confidentiality
+        : "No information"
+      }
           </p>
         </div>
         <div class="info-cards-icon">
@@ -924,9 +899,8 @@ export class AstResult extends CxResult {
         </div>
       </div>
     </div>
-    ${
-      result.vulnerabilityDetails.cvss &&
-      result.vulnerabilityDetails.cvss.integrityImpact
+    ${result.vulnerabilityDetails.cvss &&
+        result.vulnerabilityDetails.cvss.integrityImpact
         ? `
       <div class="sca-details">
         <div class="info-cards">
@@ -935,11 +909,10 @@ export class AstResult extends CxResult {
               Integrity Impact
             </p>
             <p class="info-cards-value">
-              ${
-                result.vulnerabilityDetails.cvss.integrityImpact
-                  ? result.vulnerabilityDetails.cvss.integrityImpact
-                  : "No information"
-              }
+              ${result.vulnerabilityDetails.cvss.integrityImpact
+          ? result.vulnerabilityDetails.cvss.integrityImpact
+          : "No information"
+        }
             </p>
           </div>
           <div class="info-cards-icon">
@@ -948,7 +921,7 @@ export class AstResult extends CxResult {
         </div>
       </div>`
         : ``
-    }
+      }
     <div class="sca-details">
       <div class="info-cards">
         <div class="info-cards-text">
@@ -956,12 +929,11 @@ export class AstResult extends CxResult {
             Availability Impact
           </p>
           <p class="info-cards-value">
-            ${
-              result.vulnerabilityDetails.cvss &&
-              result.vulnerabilityDetails.cvss.availability
-                ? result.vulnerabilityDetails.cvss.availability
-                : "No information"
-            }
+            ${result.vulnerabilityDetails.cvss &&
+        result.vulnerabilityDetails.cvss.availability
+        ? result.vulnerabilityDetails.cvss.availability
+        : "No information"
+      }
           </p>
         </div>
         <div class="info-cards-icon">
@@ -974,83 +946,71 @@ export class AstResult extends CxResult {
 
   private scaRemediation(result, scaUpgrade, scaUrl, type?) {
     return `
-            ${
-              !type
-                ? `<div 
-              class=${
-                result.scaNode.recommendedVersion &&
-                result.scaNode.scaPackageData.supportsQuickFix === true
-                  ? "remediation-icon"
-                  : "remediation-icon-disabled"
-              }
-              data-version="${
-                result.scaNode.recommendedVersion &&
-                result.scaNode.scaPackageData.supportsQuickFix === true
-                  ? result.scaNode.recommendedVersion
-                  : ""
-              }" 
-              data-package="${
-                result.scaNode.scaPackageData.dependencyPaths &&
-                result.scaNode.scaPackageData.dependencyPaths[0][0].name
-                  ? result.scaNode.scaPackageData.dependencyPaths[0][0].name
-                  : ""
-              }" 
-              data-file="${
-                result.scaNode.scaPackageData.dependencyPaths &&
-                result.scaNode.scaPackageData.dependencyPaths[0][0].locations
-                  ? result.scaNode.scaPackageData.dependencyPaths[0][0]
-                      .locations
-                  : ""
-              }"
+            ${!type
+        ? `<div 
+              class=${result.scaNode.recommendedVersion &&
+          result.scaNode.scaPackageData.supportsQuickFix === true
+          ? "remediation-icon"
+          : "remediation-icon-disabled"
+        }
+              data-version="${result.scaNode.recommendedVersion &&
+          result.scaNode.scaPackageData.supportsQuickFix === true
+          ? result.scaNode.recommendedVersion
+          : ""
+        }" 
+              data-package="${result.scaNode.scaPackageData.dependencyPaths &&
+          result.scaNode.scaPackageData.dependencyPaths[0][0].name
+          ? result.scaNode.scaPackageData.dependencyPaths[0][0].name
+          : ""
+        }" 
+              data-file="${result.scaNode.scaPackageData.dependencyPaths &&
+          result.scaNode.scaPackageData.dependencyPaths[0][0].locations
+          ? result.scaNode.scaPackageData.dependencyPaths[0][0]
+            .locations
+          : ""
+        }"
               >
                 <img 
-                  data-version="${
-                    result.scaNode.recommendedVersion
-                      ? result.scaNode.recommendedVersion
-                      : ""
-                  }" 
-                  data-package="${
-                    result.scaNode.scaPackageData.dependencyPaths &&
-                    result.scaNode.scaPackageData.dependencyPaths[0][0].name
-                      ? result.scaNode.scaPackageData.dependencyPaths[0][0].name
-                      : ""
-                  }" 
-                  data-file="${
-                    result.scaNode.scaPackageData.dependencyPaths &&
-                    result.scaNode.scaPackageData.dependencyPaths[0][0]
-                      .locations
-                      ? result.scaNode.scaPackageData.dependencyPaths[0][0]
-                          .locations
-                      : ""
-                  }" 
+                  data-version="${result.scaNode.recommendedVersion
+          ? result.scaNode.recommendedVersion
+          : ""
+        }" 
+                  data-package="${result.scaNode.scaPackageData.dependencyPaths &&
+          result.scaNode.scaPackageData.dependencyPaths[0][0].name
+          ? result.scaNode.scaPackageData.dependencyPaths[0][0].name
+          : ""
+        }" 
+                  data-file="${result.scaNode.scaPackageData.dependencyPaths &&
+          result.scaNode.scaPackageData.dependencyPaths[0][0]
+            .locations
+          ? result.scaNode.scaPackageData.dependencyPaths[0][0]
+            .locations
+          : ""
+        }" 
                   alt="icon" src="${scaUpgrade}" 
                   class="remediation-upgrade" />
               </div>
             <div 
-            class=${
-              result.scaNode.recommendedVersion &&
-              result.scaNode.scaPackageData.supportsQuickFix === true
-                ? "remediation-version"
-                : "remediation-version-disabled"
-            }
-            data-version="${
-              result.scaNode.recommendedVersion &&
-              result.scaNode.scaPackageData.supportsQuickFix === true
-                ? result.scaNode.recommendedVersion
-                : ""
-            }" 
-            data-package="${
-              result.scaNode.scaPackageData.dependencyPaths &&
-              result.scaNode.scaPackageData.dependencyPaths[0][0].name
-                ? result.scaNode.scaPackageData.dependencyPaths[0][0].name
-                : ""
-            }" 
-            data-file="${
-              result.scaNode.scaPackageData.dependencyPaths &&
-              result.scaNode.scaPackageData.dependencyPaths[0][0].locations
-                ? result.scaNode.scaPackageData.dependencyPaths[0][0].locations
-                : ""
-            }"
+            class=${result.scaNode.recommendedVersion &&
+          result.scaNode.scaPackageData.supportsQuickFix === true
+          ? "remediation-version"
+          : "remediation-version-disabled"
+        }
+            data-version="${result.scaNode.recommendedVersion &&
+          result.scaNode.scaPackageData.supportsQuickFix === true
+          ? result.scaNode.recommendedVersion
+          : ""
+        }" 
+            data-package="${result.scaNode.scaPackageData.dependencyPaths &&
+          result.scaNode.scaPackageData.dependencyPaths[0][0].name
+          ? result.scaNode.scaPackageData.dependencyPaths[0][0].name
+          : ""
+        }" 
+            data-file="${result.scaNode.scaPackageData.dependencyPaths &&
+          result.scaNode.scaPackageData.dependencyPaths[0][0].locations
+          ? result.scaNode.scaPackageData.dependencyPaths[0][0].locations
+          : ""
+        }"
             >
             
               <div class="remediation-version-container">
@@ -1058,35 +1018,30 @@ export class AstResult extends CxResult {
                   Upgrade To Version
                 </p>
                 <p
-                  class=${
-                    result.scaNode.recommendedVersion &&
-                    result.scaNode.scaPackageData.supportsQuickFix === true
-                      ? "version"
-                      : "version-disabled"
-                  }
-                  data-version="${
-                    result.scaNode.recommendedVersion
-                      ? result.scaNode.recommendedVersion
-                      : ""
-                  }" 
-                data-package="${
-                  result.scaNode.scaPackageData.dependencyPaths &&
-                  result.scaNode.scaPackageData.dependencyPaths[0][0].name
-                    ? result.scaNode.scaPackageData.dependencyPaths[0][0].name
-                    : ""
-                }" 
-                data-file="${
-                  result.scaNode.scaPackageData.dependencyPaths &&
-                  result.scaNode.scaPackageData.dependencyPaths[0][0].locations
-                    ? result.scaNode.scaPackageData.dependencyPaths[0][0]
-                        .locations
-                    : ""
-                }">
-                  ${
-                    result.scaNode.recommendedVersion
-                      ? result.scaNode.recommendedVersion
-                      : "Not available"
-                  }
+                  class=${result.scaNode.recommendedVersion &&
+          result.scaNode.scaPackageData.supportsQuickFix === true
+          ? "version"
+          : "version-disabled"
+        }
+                  data-version="${result.scaNode.recommendedVersion
+          ? result.scaNode.recommendedVersion
+          : ""
+        }" 
+                data-package="${result.scaNode.scaPackageData.dependencyPaths &&
+          result.scaNode.scaPackageData.dependencyPaths[0][0].name
+          ? result.scaNode.scaPackageData.dependencyPaths[0][0].name
+          : ""
+        }" 
+                data-file="${result.scaNode.scaPackageData.dependencyPaths &&
+          result.scaNode.scaPackageData.dependencyPaths[0][0].locations
+          ? result.scaNode.scaPackageData.dependencyPaths[0][0]
+            .locations
+          : ""
+        }">
+                  ${result.scaNode.recommendedVersion
+          ? result.scaNode.recommendedVersion
+          : "Not available"
+        }
                 </p>
               </div>
             </div>
@@ -1094,24 +1049,23 @@ export class AstResult extends CxResult {
               <div class="remediation-links-about">
                 <div class="remediation-links-rows">
                   <img class="remediation-links-rows-image" alt="icon" src="${scaUrl}" />
-                  ${
-                    result.scaNode.scaPackageData.fixLink &&
-                    result.scaNode.scaPackageData.fixLink !== ""
-                      ? `
+                  ${result.scaNode.scaPackageData.fixLink &&
+          result.scaNode.scaPackageData.fixLink !== ""
+          ? `
                   <p class="remediation-links-text" id="${result.scaNode.scaPackageData.fixLink}">
                     About this vulnerability
                   </p>
                 `
-                      : ` <p class="remediation-links-text-disabled" id="${result.scaNode.scaPackageData.fixLink}">
+          : ` <p class="remediation-links-text-disabled" id="${result.scaNode.scaPackageData.fixLink}">
                       About this vulnerability
                     </p>`
-                  }
+        }
                  
                 </div>
               </div>
             </div>
             `
-                : ``
-            }`;
+        : ``
+      }`;
   }
 }

--- a/src/utils/interface/details.ts
+++ b/src/utils/interface/details.ts
@@ -28,6 +28,9 @@ export class Details {
 				<div class="header-item-title">
 					<h2 id="cx_title">
 						<img class="logo" src="${severityPath}" alt="CxLogo" id="logo_img" />
+						${
+					this.result.label ?  `<span class="header-risk-score ${this.getRiskName(9.2)}-risk" style="padding:2px">9.2</span>` : ""
+				}
 						${this.result.label.replaceAll("_", " ")}
 					</h2>
 				</div>
@@ -130,6 +133,38 @@ export class Details {
 						${this.result.getHtmlDetails(cxPath)}
 					</tbody>
 				</table>	
+	  			<hr class="division">
+				<div style="border:0">
+				<div style="display: inline-block;position: relative;">
+					<p class="header-content">
+						Additional trait
+					</p>
+				</div>
+				<div class="card-content">
+						<table class="package-table" id="package-table-${0 + 1}">
+						<tbody>
+						<tr>
+							<td>
+								<div>
+								<div style="display: inline-block">
+									Suspected Malware
+								</div>
+								</div>
+							</td>
+							</tr>
+							<tr>
+							<td>
+								<div>
+								<div style="display: inline-block">
+									Exploitable Path
+								</div>
+								</div>
+							</td>
+							</tr>
+						</tbody>
+						</table>
+				</div>
+				</div>
 			</body>`;
   }
 
@@ -139,6 +174,16 @@ export class Details {
 					${this.result.description ? "<p>" + this.result.description + "</p>" : ""}
 				</span>
 				</body>`;
+  }
+
+  getRiskName(score) {
+    return score === 10
+      ? "critical"
+      : score >= 7
+      ? "high"
+      : score >= 3
+      ? "medium"
+      : "low";
   }
 
   scaView(
@@ -157,6 +202,9 @@ export class Details {
 			<body class="body-sca">
 			<div class="header">
 				<img alt="icon" class="header-severity" src="${severityPath}" />
+				${
+					this.result.label ?  `<p class="header-risk-score ${this.getRiskName(9.2)}-risk">9.2</p>` : ""
+				}
 				<p class="header-title">
 					${this.result.label}
 				</p>

--- a/src/utils/interface/details.ts
+++ b/src/utils/interface/details.ts
@@ -29,7 +29,7 @@ export class Details {
 					<h2 id="cx_title">
 						<img class="logo" src="${severityPath}" alt="CxLogo" id="logo_img" />
 						${
-					this.result.label ?  `<span class="header-risk-score ${this.getRiskName(9.2)}-risk" style="padding:2px">9.2</span>` : ""
+					this.result.riskScore ?  `<span class="header-risk-score ${this.getRiskName(this.result.riskScore)}-risk" style="padding:2px">${this.result.riskScore.toFixed(1)}</span>` : ""
 				}
 						${this.result.label.replaceAll("_", " ")}
 					</h2>
@@ -132,39 +132,18 @@ export class Details {
 					<tbody>
 						${this.result.getHtmlDetails(cxPath)}
 					</tbody>
-				</table>	
-	  			<hr class="division">
+				</table>
+				${this.result.traits !== undefined ? `<hr class="division">
 				<div style="border:0">
-				<div style="display: inline-block;position: relative;">
-					<p class="header-content">
-						Additional trait
-					</p>
-				</div>
-				<div class="card-content">
-						<table class="package-table" id="package-table-${0 + 1}">
-						<tbody>
-						<tr>
-							<td>
-								<div>
-								<div style="display: inline-block">
-									Suspected Malware
-								</div>
-								</div>
-							</td>
-							</tr>
-							<tr>
-							<td>
-								<div>
-								<div style="display: inline-block">
-									Exploitable Path
-								</div>
-								</div>
-							</td>
-							</tr>
-						</tbody>
-						</table>
-				</div>
-				</div>
+					<div style="display: inline-block;position: relative;">
+						<p class="header-content">
+							Additional trait
+						</p>
+					</div>
+					<div class="card-content">
+							${this.result.getHtmlAdditionaltrait(this.result)}
+					</div>
+				</div>` : ""}
 			</body>`;
   }
 
@@ -203,7 +182,7 @@ export class Details {
 			<div class="header">
 				<img alt="icon" class="header-severity" src="${severityPath}" />
 				${
-					this.result.label ?  `<p class="header-risk-score ${this.getRiskName(9.2)}-risk">9.2</p>` : ""
+					this.result.riskScore ?  `<p class="header-risk-score ${this.getRiskName(this.result.riskScore)}-risk">${this.result.riskScore.toFixed(1)}</p>` : ""
 				}
 				<p class="header-title">
 					${this.result.label}

--- a/src/utils/interface/details.ts
+++ b/src/utils/interface/details.ts
@@ -7,42 +7,41 @@ import { messages } from "../common/messages";
 import { getGlobalContext } from "../../extension";
 
 export class Details {
-  result: AstResult;
-  context: vscode.ExtensionContext;
-  iAIEnabled: boolean;
-  masked?: CxMask;
+	result: AstResult;
+	context: vscode.ExtensionContext;
+	iAIEnabled: boolean;
+	masked?: CxMask;
 
-  constructor(
-    result: AstResult,
-    context: vscode.ExtensionContext,
-    iAIEnabled: boolean
-  ) {
-    this.result = result;
-    this.context = context;
-    this.iAIEnabled = iAIEnabled;
-  }
+	constructor(
+		result: AstResult,
+		context: vscode.ExtensionContext,
+		iAIEnabled: boolean
+	) {
+		this.result = result;
+		this.context = context;
+		this.iAIEnabled = iAIEnabled;
+	}
 
-  header(severityPath: vscode.Uri) {
-    return `
+	header(severityPath: vscode.Uri) {
+		return `
 			<div class="header-container">
 				<div class="header-item-title">
 					<h2 id="cx_title">
 						<img class="logo" src="${severityPath}" alt="CxLogo" id="logo_img" />
-						${
-					this.result.riskScore ?  `<span class="header-risk-score ${this.getRiskName(this.result.riskScore)}-risk" style="padding:2px">${this.result.riskScore.toFixed(1)}</span>` : ""
-				}
+						${this.result.riskScore ? `<span class="header-risk-score ${this.getRiskName(this.result.riskScore)}-risk" style="padding:2px">${this.result.riskScore.toFixed(1)}</span>` : ""
+			}
 						${this.result.label.replaceAll("_", " ")}
 					</h2>
 				</div>
 			</div>
 			<hr class="division"/>
 			`;
-  }
+	}
 
-  changes(selectClassname): string {
-    return (
-      this.triage(selectClassname) +
-      `
+	changes(selectClassname): string {
+		return (
+			this.triage(selectClassname) +
+			`
 			<div id="history-container-loader">
 				<center>
 					<p class="history-container-loader">
@@ -53,76 +52,73 @@ export class Details {
 				</center>
 			</div>
 			`
-    );
-  }
+		);
+	}
 
-  triage(selectClassname: string) {
-    const context = getGlobalContext();
-    const customStates = context.globalState.get(constants.customStates);
-    const state = constants.state.filter((element) => {
-      return !!element.dependency === (this.result.type === constants.sca);
-    });
+	triage(selectClassname: string) {
+		const context = getGlobalContext();
+		const customStates = context.globalState.get(constants.customStates);
+		const state = constants.state.filter((element) => {
+			return !!element.dependency === (this.result.type === constants.sca);
+		});
 
-    const stateOptions =
-      this.result.type === constants.sast
-        ? this.getSastStateOptions(customStates, state)
-        : this.getDefaultStateOptions(state);
+		const stateOptions =
+			this.result.type === constants.sast
+				? this.getSastStateOptions(customStates, state)
+				: this.getDefaultStateOptions(state);
 
-    const updateButton =
-      this.result.type !== constants.sca
-        ? `<button class="submit">Update</button>`
-        : ``;
-    const comment =
-      this.result.type !== constants.sca
-        ? `<div class="comment-container">
+		const updateButton =
+			this.result.type !== constants.sca
+				? `<button class="submit">Update</button>`
+				: ``;
+		const comment =
+			this.result.type !== constants.sca
+				? `<div class="comment-container">
         <textarea placeholder="Comment (optional)" cols="41" rows="3" class="comments" type="text" id="comment_box"></textarea>
       </div>`
-        : ``;
+				: ``;
 
-    return `<div class="ast-triage">
+		return `<div class="ast-triage">
         <select id="select_severity" onchange="this.className=this.options[this.selectedIndex].className" class=${selectClassname}>
           ${constants.status.map((element) => {
-            return `<option id=${element.value} class="${element.class}" ${
-              this.result.severity === element.value ? "selected" : ""
-            }>${element.value}</option>`;
-          })}
+			return `<option id=${element.value} class="${element.class}" ${this.result.severity === element.value ? "selected" : ""
+				}>${element.value}</option>`;
+		})}
         </select>
         ${stateOptions}
       </div>
       ${comment}
       ${updateButton}
       </br>`;
-  }
+	}
 
-  getSastStateOptions(customStates, state) {
-    return `<select id="select_state" class="state">
+	getSastStateOptions(customStates, state) {
+		return `<select id="select_state" class="state">
       ${customStates
-        .map((customState) => {
-          const matchedState = state.find(
-            (element) => element.tag === customState.name
-          );
-          return `<option id=${customState.name} ${
-            this.result.state?.toLowerCase() === customState.name ||
-            this.result.state === matchedState?.tag
-              ? 'selected="selected"'
-              : ""
-          }>${matchedState ? matchedState.value : customState.name}</option>`;
-        })
-        .join("")}
+				.map((customState) => {
+					const matchedState = state.find(
+						(element) => element.tag === customState.name
+					);
+					return `<option id=${customState.name} ${this.result.state?.toLowerCase() === customState.name ||
+						this.result.state === matchedState?.tag
+						? 'selected="selected"'
+						: ""
+						}>${matchedState ? matchedState.value : customState.name}</option>`;
+				})
+				.join("")}
     </select>`;
-  }
+	}
 
-  getDefaultStateOptions(state) {
-    return `<select id="select_state" class="state">
+	getDefaultStateOptions(state) {
+		return `<select id="select_state" class="state">
       ${state.map((element) => {
-        return `<option id=${element.value} ${
-          this.result.state === element.tag ? 'selected="selected"' : ""
-        }>${element.value}</option>`;
-      })}
+			return `<option id=${element.value} ${this.result.state === element.tag ? 'selected="selected"' : ""
+				}>${element.value}</option>`;
+		})}
     </select>`;
-  }
-  generalTab(cxPath: vscode.Uri) {
-    return `<body>
+	}
+	generalTab(cxPath: vscode.Uri) {
+		return `<body>
 				<span class="details">
 					${this.result.description ? "<p>" + this.result.description + "</p>" : ""}
 					${this.result.data.value ? this.result.getKicsValues() : ""}
@@ -145,76 +141,74 @@ export class Details {
 					</div>
 				</div>` : ""}
 			</body>`;
-  }
+	}
 
-  secretDetectiongeneralTab() {
-    return `<body>
+	secretDetectiongeneralTab() {
+		return `<body>
 				<span>
 					${this.result.description ? "<p>" + this.result.description + "</p>" : ""}
 				</span>
 				</body>`;
-  }
+	}
 
-  getRiskName(score) {
-    return score === 10
-      ? "critical"
-      : score >= 7
-      ? "high"
-      : score >= 3
-      ? "medium"
-      : "low";
-  }
+	getRiskName(score) {
+		return score === 10
+			? "critical"
+			: score >= 7
+				? "high"
+				: score >= 3
+					? "medium"
+					: "low";
+	}
 
-  scaView(
-    severityPath,
-    scaAtackVector,
-    scaComplexity,
-    scaAuthentication,
-    scaConfidentiality,
-    scaIntegrity,
-    scaAvailability,
-    scaUpgrade,
-    scaUrl: vscode.Uri,
-    type?: string
-  ) {
-    return `
+	scaView(
+		severityPath,
+		scaAtackVector,
+		scaComplexity,
+		scaAuthentication,
+		scaConfidentiality,
+		scaIntegrity,
+		scaAvailability,
+		scaUpgrade,
+		scaUrl: vscode.Uri,
+		type?: string
+	) {
+		return `
 			<body class="body-sca">
 			<div class="header">
 				<img alt="icon" class="header-severity" src="${severityPath}" />
-				${
-					this.result.riskScore ?  `<p class="header-risk-score ${this.getRiskName(this.result.riskScore)}-risk">${this.result.riskScore.toFixed(1)}</p>` : ""
-				}
+				${this.result.riskScore ? `<p class="header-risk-score ${this.getRiskName(this.result.riskScore)}-risk">${this.result.riskScore.toFixed(1)}</p>` : ""
+			}
 				<p class="header-title">
 					${this.result.label}
 				</p>
 				<p class="header-name">
-					${
-            this.result.scaNode.packageIdentifier
-              ? this.result.scaNode.packageIdentifier
-              : ""
-          }
+					${this.result.scaNode.packageIdentifier
+				? this.result.scaNode.packageIdentifier
+				: ""
+			}
 				</p>
 			</div>
 			<div class="content">
 				${this.result.scaContent(
-          this.result,
-          scaUpgrade,
-          scaUrl,
-          scaAtackVector,
-          scaComplexity,
-          scaAuthentication,
-          scaConfidentiality,
-          scaIntegrity,
-          scaAvailability,
-          type
-        )}
+				this.result,
+				scaUpgrade,
+				scaUrl,
+				scaAtackVector,
+				scaComplexity,
+				scaAuthentication,
+				scaConfidentiality,
+				scaIntegrity,
+				scaAvailability,
+				type
+			)}
 			</div>
 		</body>			
 		`;
-  }
+	}
 
-  detailsTab() {
-    return `
+	detailsTab() {
+		return `
 			<div>
 				<div id="learn-container-loader">
 					<center>
@@ -227,113 +221,104 @@ export class Details {
 				</div>
 			</div>
 			`;
-  }
+	}
 
-  secretDetectionDetailsRemediationTab() {
-    const remediation = this.result.data?.remediation;
+	secretDetectionDetailsRemediationTab() {
+		const remediation = this.result.data?.remediation;
 
-    if (!remediation) {
-      return `<div>${messages.noRemediationExamplesTab}</div>`;
-    }
+		if (!remediation) {
+			return `<div>${messages.noRemediationExamplesTab}</div>`;
+		}
 
-    return `
+		return `
 	  <div>
 		${remediation ? `<p>${remediation}</p>` : ""}
 	  </div>
 	`;
-  }
+	}
 
-  secretDetectionDetailsDescriptionTab() {
-    const ruleDescription = this.result.data?.ruleDescription;
+	secretDetectionDetailsDescriptionTab() {
+		const ruleDescription = this.result.data?.ruleDescription;
 
-    if (!ruleDescription) {
-      return `<div>${messages.noDescriptionTab}</div>`;
-    }
+		if (!ruleDescription) {
+			return `<div>${messages.noDescriptionTab}</div>`;
+		}
 
-    return `
+		return `
 	  <div>
 	  ${ruleDescription ? `<p>${ruleDescription}</p>` : ""}
 	  </div>
 	`;
-  }
+	}
 
-  // Generic tab component
-  tab(
-    tab1Content: string,
-    tab2Content: string,
-    tab3Content: string,
-    tab1Label: string,
-    tab2Label: string,
-    tab3Label: string,
-    tab4Label: string,
-    tab5Content: string,
-    tab6Label: string,
-    tab6Content: string
-  ) {
-    return `${
-      tab1Label !== ""
-        ? `<input type="radio" name="tabs" id="general-tab" checked />
+	// Generic tab component
+	tab(
+		tab1Content: string,
+		tab2Content: string,
+		tab3Content: string,
+		tab1Label: string,
+		tab2Label: string,
+		tab3Label: string,
+		tab4Label: string,
+		tab5Content: string,
+		tab6Label: string,
+		tab6Content: string
+	) {
+		return `${tab1Label !== ""
+			? `<input type="radio" name="tabs" id="general-tab" checked />
 			<label for="general-tab" id="general-label">
 				${tab1Label}
 			</label>`
-        : ""
-    }
-			${
-        tab2Label !== ""
-          ? `<input type="radio" name="tabs" id="learn-tab" />
+			: ""
+			}
+			${tab2Label !== ""
+				? `<input type="radio" name="tabs" id="learn-tab" />
 			<label for="learn-tab" id="learn-label">
 				${tab2Label}
 			</label>`
-          : ""
-      }
-			${
-        tab4Label !== ""
-          ? `<input type="radio" name="tabs" id="code-tab" />
+				: ""
+			}
+			${tab4Label !== ""
+				? `<input type="radio" name="tabs" id="code-tab" />
 			<label for="code-tab" id="code-label">
 				${tab4Label}
 			</label>`
-          : ""
-      }
-			${
-        tab6Label !== ""
-          ? `<input type="radio" name="tabs" id="ai-tab" />
+				: ""
+			}
+			${tab6Label !== ""
+				? `<input type="radio" name="tabs" id="ai-tab" />
 			<label for="ai-tab" id="ai-label">
 				${tab6Label}
 			</label>`
-          : ""
-      }
-			${
-        tab3Label !== ""
-          ? `<input type="radio" name="tabs" id="changes-tab" />
+				: ""
+			}
+			${tab3Label !== ""
+				? `<input type="radio" name="tabs" id="changes-tab" />
 		<label for="changes-tab" id="changes-label">
 			${tab3Label}
 		</label>`
-          : ""
-      }
-			${
-        tab1Content !== ""
-          ? `<div class="tab general">
+				: ""
+			}
+			${tab1Content !== ""
+				? `<div class="tab general">
 			${tab1Content}
 			</div>`
-          : ""
-      }
-			${
-        tab2Content !== ""
-          ? `<div class="tab learn">
+				: ""
+			}
+			${tab2Content !== ""
+				? `<div class="tab learn">
 			${tab2Content}
 			</div>`
-          : ""
-      }
-			${
-        tab3Content !== ""
-          ? `<div class="tab changes">
+				: ""
+			}
+			${tab3Content !== ""
+				? `<div class="tab changes">
 			${tab3Content}
 		</div>`
-          : ""
-      }
-		${
-      tab5Content !== ""
-        ? `<div class="tab code">
+				: ""
+			}
+		${tab5Content !== ""
+				? `<div class="tab code">
 		<div id="tab-code">
 			<pre class="pre-code">
 				<code id="code">
@@ -342,20 +327,19 @@ export class Details {
 			</pre>
 		</div>
 	</div>`
-        : ""
-    }
-			${
-        tab6Content !== ""
-          ? `<div class="tab ai">
+				: ""
+			}
+			${tab6Content !== ""
+				? `<div class="tab ai">
 					${tab6Content}
 				  </div>`
-          : ""
-      }
+				: ""
+			}
 			`;
-  }
-  guidedRemediationSastTab(kicsIcon, masked: CxMask) {
-    this.masked = masked;
-    return `
+	}
+	guidedRemediationSastTab(kicsIcon, masked: CxMask) {
+		this.masked = masked;
+		return `
 		<div class="inner-body-sast" id="innerBodySast" style="min-height: 80vh;display: flex;justify-content: center;align-items: center;">
 		<button id="startSastChat" class="start-sast-chat">
 			<div class="row">
@@ -373,15 +357,15 @@ export class Details {
 		</button>
 		</div>
 		`;
-  }
+	}
 
-  guidedRemediationTab(kicsIcon, masked: CxMask) {
-    // TODO: try to make it generic to be used by the tab and the webview
-    this.masked = masked;
-    const userInfo = os.userInfo();
-    // Access the username
-    const username = userInfo.username;
-    return `
+	guidedRemediationTab(kicsIcon, masked: CxMask) {
+		// TODO: try to make it generic to be used by the tab and the webview
+		this.masked = masked;
+		const userInfo = os.userInfo();
+		// Access the username
+		const username = userInfo.username;
+		return `
 		<div class="inner-body">
 		<div>
 	<div class="container" style="padding:0;width:100 !important;">
@@ -398,9 +382,8 @@ export class Details {
 				<div class="row" style="margin-top:0.8em">
 					<div class="col">
 						<p>Welcome ${username}!</p>
-						<p>”${
-              constants.aiSecurityChampion
-            }” harnesses the power of AI to help you to understand the
+						<p>”${constants.aiSecurityChampion
+			}” harnesses the power of AI to help you to understand the
 							vulnerabilities in your code, and resolve them quickly and easily.</p>
 						<p style="margin-bottom:0">We protect your sensitive data by anonymizing the source file
 							before sending data to GPT.</p>
@@ -415,11 +398,10 @@ export class Details {
 									<button class="btn btn-link" data-toggle="collapse" data-target="#collapseOne"
 										aria-expanded="true" aria-controls="collapseOne"
 										style="color:var(--vscode-editor-foreground);text-align:left">
-										Masked Secrets ${
-                      this.masked && this.masked.maskedSecrets
-                        ? "(" + this.masked.maskedSecrets.length + ")"
-                        : ""
-                    }
+										Masked Secrets ${this.masked && this.masked.maskedSecrets
+				? "(" + this.masked.maskedSecrets.length + ")"
+				: ""
+			}
 									</button>
 								</h5>
 							</div>
@@ -495,9 +477,8 @@ export class Details {
 		<div class="row" style="margin-top:1em">
 			<div class="col">
 				<p style="color:#676972;font-size:12px">
-					”${
-            constants.aiSecurityChampion
-          }” will only answer questions that are relevant to this IaC file and its
+					”${constants.aiSecurityChampion
+			}” will only answer questions that are relevant to this IaC file and its
 					results.The responses are generated by OpenAI's GPT. The content may contain inaccuracies. Use
 					your judgement in determining how to utilize this information.
 				</p>
@@ -539,31 +520,31 @@ export class Details {
 </button>
 </div>
 		`;
-  }
+	}
 
-  generateMaskedSection(): string {
-    let html = "";
-    if (
-      this.masked &&
-      this.masked.maskedSecrets &&
-      this.masked.maskedSecrets.length > 0
-    ) {
-      for (let i = 0; i < this.masked.maskedSecrets.length; i++) {
-        html +=
-          "<p>Secret: " +
-          this.masked.maskedSecrets[i].secret +
-          "<br/>" +
-          "Masked: " +
-          this.masked.maskedSecrets[i].masked
-            .replaceAll("<", "&lt;")
-            .replaceAll(">", "&gt;") +
-          "<br/>Line: " +
-          this.masked.maskedSecrets[i].line +
-          "</p>";
-      }
-    } else {
-      html += "No secrets were detected and masked";
-    }
-    return html;
-  }
+	generateMaskedSection(): string {
+		let html = "";
+		if (
+			this.masked &&
+			this.masked.maskedSecrets &&
+			this.masked.maskedSecrets.length > 0
+		) {
+			for (let i = 0; i < this.masked.maskedSecrets.length; i++) {
+				html +=
+					"<p>Secret: " +
+					this.masked.maskedSecrets[i].secret +
+					"<br/>" +
+					"Masked: " +
+					this.masked.maskedSecrets[i].masked
+						.replaceAll("<", "&lt;")
+						.replaceAll(">", "&gt;") +
+					"<br/>Line: " +
+					this.masked.maskedSecrets[i].line +
+					"</p>";
+			}
+		} else {
+			html += "No secrets were detected and masked";
+		}
+		return html;
+	}
 }

--- a/src/views/riskManagementView/riskManagementView.ts
+++ b/src/views/riskManagementView/riskManagementView.ts
@@ -46,11 +46,11 @@ export class riskManagementView implements vscode.WebviewViewProvider {
 
   private async handleMessage(message: {
     command: string;
-    result?: { hash: string };
+    result?: { hash: string ,riskScore: number, traits: { [key: string]: string } };
   }): Promise<void> {
     switch (message.command) {
       case "openVulnerabilityDetails": {
-        const result = this.findResultByHash(message.result.hash);
+        const result = this.findResultByHash(message.result.hash,message.result.riskScore,message.result.traits);
         if (result) {
           const astResult = new AstResult(result);
           await vscode.commands.executeCommand(commands.newDetails, astResult);
@@ -62,8 +62,13 @@ export class riskManagementView implements vscode.WebviewViewProvider {
     }
   }
 
-  private findResultByHash(hash: string): CxResult | undefined {
-    return this.cxResults.find((result) => result.alternateId === hash);
+  private findResultByHash(hash: string,riskScore:number,traits: { [key: string]: string } = {}): CxResult | undefined {
+    const result  = this.cxResults.find((result) => result.alternateId === hash);
+    if (result) {
+      result.riskScore = riskScore;
+      result.traits = traits;
+    }
+    return result;
   }
 
   public async updateContent(options?: {


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](../docs/code_of_conduct.md). Please see the [contributing guidelines](../docs/contributing.md) for how to create and submit a high-quality PR for this repo.

### Description

> On clicks in one of the risks (independent of the engine) the risk info window will display the normal info with risk score in the title and the Additional Trait section at the bottom of the page


### Testing

- Log in with master tenant
- Select any of the project, branch and latest scan e.g., Liza_privat_package \ RISK_MGMT_sast_project \ ALL_ENGINES_RESULTS_FOR_BYOR_TEST_project 
-  ASPM results will be displayed
- Click on any risk and verify risk-score and additional traits.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR (if applicable).
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used