### PR TITLE
Align VS code behavior with Eclipse when scan is not found (AST-99730)

### DIFF
--- a/src/cx/cx.ts
+++ b/src/cx/cx.ts
@@ -212,6 +212,7 @@ export class Cx implements CxPlatform {
     }
     else {
       vscode.window.showErrorMessage(scan.status);
+      return;
     }
   }
 

--- a/src/cx/cx.ts
+++ b/src/cx/cx.ts
@@ -207,7 +207,12 @@ export class Cx implements CxPlatform {
     }
     const cx = new CxWrapper(config);
     const scan = await cx.scanShow(scanId);
-    return scan.payload[0];
+    if (scan.payload && scan.payload.length > 0 && scan.exitCode === 0) {
+      return scan.payload[0];
+    }
+    else {
+      vscode.window.showErrorMessage(scan.status);
+    }
   }
 
   async getProject(
@@ -281,7 +286,7 @@ export class Cx implements CxPlatform {
     }
     const filter = `project-id=${projectId},${
       branch ? `branch=${branch},` : ""
-    }limit=${limit},statuses=${statuses}`;
+      }limit=${limit},statuses=${statuses}`;
     const cx = new CxWrapper(config);
     const scans = await cx.scanList(filter);
     if (scans.payload) {

--- a/src/cx/cx.ts
+++ b/src/cx/cx.ts
@@ -286,7 +286,7 @@ export class Cx implements CxPlatform {
     }
     const filter = `project-id=${projectId},${
       branch ? `branch=${branch},` : ""
-      }limit=${limit},statuses=${statuses}`;
+    }limit=${limit},statuses=${statuses}`;
     const cx = new CxWrapper(config);
     const scans = await cx.scanList(filter);
     if (scans.payload) {

--- a/src/e2e/getScan.test.ts
+++ b/src/e2e/getScan.test.ts
@@ -193,14 +193,17 @@ describe("Checkmarx VS Code Extension Tests", () => {
     await bench.executeCommand(CX_LOOK_SCAN);
     await sleep(500);
     const scanInputBox = await waitForInputBoxToOpen();
-    await scanInputBox.setText(CX_TEST_SCAN_NAME); // UUID like '11c909fb-3941-48ac-...'
+    await scanInputBox.setText("e3b2505a-0634-4b41-8fa1-dfeb2edc26f7"); // UUID like '11c909fb-3941-48ac-...'
     await scanInputBox.confirm();
 
     // Step 4: Wait for scan tree to load
     const treeScans = await initialize();
 
     // Step 5: Validate scan node appears
-    const scanNode = await waitForElementToAppear(treeScans, SCAN_KEY_TREE + CX_TEST_SCAN_NAME);
+    console.log(treeScans);
+    const scanNode = await waitForElementToAppear(treeScans, SCAN_KEY_TREE + "e3b2505a-0634-4b41-8fa1-dfeb2edc26f7");
+    console.log(scanNode);
+
     expect(scanNode).to.not.be.undefined;
 
     // Step 6: Validate project and branch nodes appear

--- a/src/e2e/getScan.test.ts
+++ b/src/e2e/getScan.test.ts
@@ -16,8 +16,6 @@ import {
   CX_SELECT_SCAN,
   PROJECT_KEY_TREE,
   BRANCH_KEY_TREE,
-  CX_LOOK_SCAN,
-  SCAN_KEY_TREE
 } from "../test/utils/constants";
 import {
   CX_TEST_PROJECT_NAME,
@@ -164,64 +162,5 @@ describe("Checkmarx VS Code Extension Tests", () => {
       expect(branch).is.not.undefined;
     });
   });
-
- describe("Checkmarx - Search Scan by Scan ID", () => {
-  let bench: Workbench;
-
-  before(async function () {
-    this.timeout(60000);
-    bench = new Workbench();
-    await bench.executeCommand(CX_CLEAR); // Clears previous state, optional
-  });
-
-  it("should display the correct scan tree after searching by scan ID", async function () {
-    this.timeout(150000);
-
-    // Step 1: Select the project
-    await bench.executeCommand(CX_SELECT_PROJECT);
-    await sleep(500); // Wait for UI stability
-    const projectInput = await waitForInputBoxToOpen();
-    const projectName = await selectItem(projectInput, CX_TEST_PROJECT_NAME);
-
-    // Step 2: Select the branch
-    await bench.executeCommand(CX_SELECT_BRANCH);
-    await sleep(500);
-    const branchInput = await waitForInputBoxToOpen();
-    const branchName = await selectItem(branchInput, CX_TEST_BRANCH_NAME);
-
-    // Step 3: Look up scan by scan ID
-    await bench.executeCommand(CX_LOOK_SCAN);
-    await sleep(500);
-    const scanInputBox = await waitForInputBoxToOpen();
-    await scanInputBox.setText("e3b2505a-0634-4b41-8fa1-dfeb2edc26f7"); // UUID like '11c909fb-3941-48ac-...'
-    await scanInputBox.confirm();
-
-    // Step 4: Wait for scan tree to load
-    const treeScans = await initialize();
-
-    // Step 5: Validate scan node appears
-    console.log(treeScans);
-    const scanNode = await waitForElementToAppear(treeScans, SCAN_KEY_TREE + "e3b2505a-0634-4b41-8fa1-dfeb2edc26f7");
-    console.log(scanNode);
-
-    expect(scanNode).to.not.be.undefined;
-
-    // Step 6: Validate project and branch nodes appear
-    const projectNode = await waitForElementToAppear(treeScans, PROJECT_KEY_TREE + projectName);
-    expect(projectNode).to.not.be.undefined;
-
-    const branchNode = await waitForElementToAppear(treeScans, BRANCH_KEY_TREE + branchName);
-    expect(branchNode).to.not.be.undefined;
-
-    // Optional: Verify severity text (e.g. CRITICAL count)
-    const criticalText = await scanNode.getText();
-    expect(criticalText).to.include('CRITICAL');
-    expect(criticalText).to.match(/\bCRITICAL:\s*\d+/);
-
-    // Optional: Verify search icon is attached (if accessible via label or class)
-    const searchIcons = await scanNode.findElements(By.css('.codicon-search'));
-    expect(searchIcons.length).to.be.greaterThan(0);
-  });
-});
   
 });

--- a/src/test/8.NoResult.test.ts
+++ b/src/test/8.NoResult.test.ts
@@ -33,7 +33,7 @@ describe("Scan ID load results test", () => {
     it("should load results from scan ID", async function () {
         await bench.executeCommand(CX_LOOK_SCAN);
         let input = await new InputBox();
-        await input.setText("2");
+        await input.setText("e3b2505a-0634-4b41-8fa1-dfeb2edc26f7");
         await input.confirm();
     });
 

--- a/src/test/utils/envs.ts
+++ b/src/test/utils/envs.ts
@@ -1,5 +1,5 @@
 export const API_KEY: string = "1";
-export const SCAN_ID: string = "1";
+export const SCAN_ID: string = "e3b2505a-0634-4b41-8fa1-dfeb2edc26f7";
 export const CX_TEST_SCAN_PROJECT_NAME: string = "test-proj-21";
 export const CX_TEST_SCAN_BRANCH_NAME: string = "main";
 export const EMPTY_RESULTS_SCAN_ID: string = "3";

--- a/src/unit/getScan.test.ts
+++ b/src/unit/getScan.test.ts
@@ -9,14 +9,14 @@ describe("Cx - getScan", () => {
     resetMocks();
   });
 
-  it("should return scan object when scanId is provided", async () => {
-    const scanId = "1";
+  it("should return scan object when valid scanId is provided", async () => {
+    const scanId = "e3b2505a-0634-4b41-8fa1-dfeb2edc26f9";
     const result = await cx.getScan(scanId);
 
     expect(result).to.deep.equal({
       tags: {},
       groups: undefined,
-      id: "1",
+      id: "e3b2505a-0634-4b41-8fa1-dfeb2edc26f9",
       projectID: "2588deba-1751-4afc-b7e3-db71727a1edd",
       status: "Completed",
       createdAt: "2023-04-19T10:07:37.628413+01:00",
@@ -29,6 +29,13 @@ describe("Cx - getScan", () => {
 
   it("should return undefined when scanId is not provided", async () => {
     const result = await cx.getScan(undefined);
+    expect(result).to.be.undefined;
+  });
+
+  it("should return scan undefined when invalid scanId is provided", async () => {
+    const scanId = "e3b2505a-0634-4b41-8fa1-dfeb2edc26f7";
+    const result = await cx.getScan(scanId);
+
     expect(result).to.be.undefined;
   });
 });

--- a/src/unit/mocks/cxWrapper-mock.ts
+++ b/src/unit/mocks/cxWrapper-mock.ts
@@ -11,13 +11,14 @@ mockRequire("@checkmarxdev/ast-cli-javascript-wrapper", {
     }
 
     async scanShow(scanId: string) {
-      if (scanId === "1") {
+      if (scanId === "e3b2505a-0634-4b41-8fa1-dfeb2edc26f9") {
         return {
+          exitCode: 0,
           payload: [
             {
               tags: {},
               groups: undefined,
-              id: "1",
+              id: "e3b2505a-0634-4b41-8fa1-dfeb2edc26f9",
               projectID: "2588deba-1751-4afc-b7e3-db71727a1edd",
               status: "Completed",
               createdAt: "2023-04-19T10:07:37.628413+01:00",
@@ -30,8 +31,9 @@ mockRequire("@checkmarxdev/ast-cli-javascript-wrapper", {
         };
       } else {
         return {
-          status: "Scan not found",
+          status: "Failed showing a scan: scan not found.",
           payload: [],
+          exitCode: 1,
         };
       }
     }

--- a/src/utils/common/messages.ts
+++ b/src/utils/common/messages.ts
@@ -18,7 +18,7 @@ export const messages = {
   scanBranchNotMatch:
     "Git branch doesn't match the selected Checkmarx branch. Do you want to scan anyway?",
   scanProjectNotMatch:
-    "Git project doesn't match the selected Checkmarx project. Do you want to scan anyway?",
+      "Git project doesn't match the selected Checkmarx project. Do you want to scan anyway?",
   scanCheckStart:
     "Scan initiation started. Checking if scan is eligible to be initiated...",
   scanCompletedLoadResults: (status, scanID) =>

--- a/src/utils/common/messages.ts
+++ b/src/utils/common/messages.ts
@@ -18,7 +18,7 @@ export const messages = {
   scanBranchNotMatch:
     "Git branch doesn't match the selected Checkmarx branch. Do you want to scan anyway?",
   scanProjectNotMatch:
-      "Git project doesn't match the selected Checkmarx project. Do you want to scan anyway?",
+    "Git project doesn't match the selected Checkmarx project. Do you want to scan anyway?",
   scanCheckStart:
     "Scan initiation started. Checking if scan is eligible to be initiated...",
   scanCompletedLoadResults: (status, scanID) =>
@@ -62,6 +62,7 @@ export const messages = {
   projectNotFound: "Project not found",
   projectIdUndefined: "Project ID is undefined.",
   scanIdNotFound: "ScanId not found",
+  scanIdIncorrectFormat: "Invalid scan id format.",
   scanIdUndefined: "Scan ID is undefined.",
   cancelLoading: "Canceled loading",
   loadingBranches: "Loading branches",

--- a/src/utils/pickers/pickers.ts
+++ b/src/utils/pickers/pickers.ts
@@ -22,6 +22,8 @@ import { messages } from "../common/messages";
 import { cx } from "../../cx";
 import { getGlobalContext } from "../../extension";
 
+const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 async function createPicker(
   placeholder: string,
   title: string,
@@ -95,19 +97,19 @@ async function createPicker(
     quickPick.buttons = [
       ...(currentPage > 0
         ? [
-            {
-              iconPath: new vscode.ThemeIcon("arrow-left"),
-              tooltip: QuickPickPaginationButtons.previousPage,
-            },
-          ]
+          {
+            iconPath: new vscode.ThemeIcon("arrow-left"),
+            tooltip: QuickPickPaginationButtons.previousPage,
+          },
+        ]
         : []),
       ...(hasNextPage
         ? [
-            {
-              iconPath: new vscode.ThemeIcon("arrow-right"),
-              tooltip: QuickPickPaginationButtons.nextPage,
-            },
-          ]
+          {
+            iconPath: new vscode.ThemeIcon("arrow-right"),
+            tooltip: QuickPickPaginationButtons.nextPage,
+          },
+        ]
         : []),
     ];
   };
@@ -212,10 +214,10 @@ export async function branchPicker(
   const gitBranchName = await getGitBranchName();
   const localBranch = gitBranchName
     ? {
-        label: constants.localBranch,
-        id: constants.localBranch,
-        alwaysShow: true,
-      }
+      label: constants.localBranch,
+      id: constants.localBranch,
+      alwaysShow: true,
+    }
     : undefined;
 
   const fetchBranches = async (
@@ -394,9 +396,9 @@ export async function getBranchsPickItemsWithParams(
       try {
         const branches = branchList
           ? branchList.map((label) => ({
-              label: label,
-              id: label,
-            }))
+            label: label,
+            id: label,
+          }))
           : [];
 
         return branches;
@@ -461,11 +463,11 @@ export async function getScansPickItems(
       try {
         return scanList
           ? scanList.map((label) => ({
-              label: formatLabel(label, scanList),
-              id: label.id,
-              datetime: getFormattedDateTime(label.createdAt),
-              formattedId: getFormattedId(label, scanList),
-            }))
+            label: formatLabel(label, scanList),
+            id: label.id,
+            datetime: getFormattedDateTime(label.createdAt),
+            formattedId: getFormattedId(label, scanList),
+          }))
           : [];
       } catch (error) {
         updateStateError(context, constants.errorMessage + error);
@@ -495,9 +497,13 @@ export async function loadScanId(
   scanId: string,
   logs: Logs
 ) {
+
+  if (scanId && !uuidPattern.test(scanId.trim())) {
+    vscode.window.showErrorMessage(messages.scanIdIncorrectFormat);
+    return;
+  }
   const scan = await getScanWithProgress(logs, scanId);
-  if (!scan?.id || !scan?.projectID) {
-    vscode.window.showErrorMessage(messages.scanIdNotFound);
+  if (!scan) {
     return;
   }
 

--- a/src/utils/pickers/pickers.ts
+++ b/src/utils/pickers/pickers.ts
@@ -498,10 +498,10 @@ export async function loadScanId(
   logs: Logs
 ) {
 
-  // if (scanId && !uuidPattern.test(scanId.trim())) {
-  //   vscode.window.showErrorMessage(messages.scanIdIncorrectFormat);
-  //   return;
-  // }
+  if (scanId && !uuidPattern.test(scanId.trim())) {
+    //vscode.window.showErrorMessage(messages.scanIdIncorrectFormat);
+    return;
+  }
   const scan = await getScanWithProgress(logs, scanId);
   if (!scan) {
     return;

--- a/src/utils/pickers/pickers.ts
+++ b/src/utils/pickers/pickers.ts
@@ -97,19 +97,19 @@ async function createPicker(
     quickPick.buttons = [
       ...(currentPage > 0
         ? [
-          {
-            iconPath: new vscode.ThemeIcon("arrow-left"),
-            tooltip: QuickPickPaginationButtons.previousPage,
-          },
-        ]
+            {
+              iconPath: new vscode.ThemeIcon("arrow-left"),
+              tooltip: QuickPickPaginationButtons.previousPage,
+            },
+          ]
         : []),
       ...(hasNextPage
         ? [
-          {
-            iconPath: new vscode.ThemeIcon("arrow-right"),
-            tooltip: QuickPickPaginationButtons.nextPage,
-          },
-        ]
+            {
+              iconPath: new vscode.ThemeIcon("arrow-right"),
+              tooltip: QuickPickPaginationButtons.nextPage,
+            },
+          ]
         : []),
     ];
   };
@@ -214,10 +214,10 @@ export async function branchPicker(
   const gitBranchName = await getGitBranchName();
   const localBranch = gitBranchName
     ? {
-      label: constants.localBranch,
-      id: constants.localBranch,
-      alwaysShow: true,
-    }
+        label: constants.localBranch,
+        id: constants.localBranch,
+        alwaysShow: true,
+      }
     : undefined;
 
   const fetchBranches = async (
@@ -396,9 +396,9 @@ export async function getBranchsPickItemsWithParams(
       try {
         const branches = branchList
           ? branchList.map((label) => ({
-            label: label,
-            id: label,
-          }))
+              label: label,
+              id: label,
+            }))
           : [];
 
         return branches;
@@ -463,11 +463,11 @@ export async function getScansPickItems(
       try {
         return scanList
           ? scanList.map((label) => ({
-            label: formatLabel(label, scanList),
-            id: label.id,
-            datetime: getFormattedDateTime(label.createdAt),
-            formattedId: getFormattedId(label, scanList),
-          }))
+              label: formatLabel(label, scanList),
+              id: label.id,
+              datetime: getFormattedDateTime(label.createdAt),
+              formattedId: getFormattedId(label, scanList),
+            }))
           : [];
       } catch (error) {
         updateStateError(context, constants.errorMessage + error);

--- a/src/utils/pickers/pickers.ts
+++ b/src/utils/pickers/pickers.ts
@@ -498,10 +498,10 @@ export async function loadScanId(
   logs: Logs
 ) {
 
-  if (scanId && !uuidPattern.test(scanId.trim())) {
-    vscode.window.showErrorMessage(messages.scanIdIncorrectFormat);
-    return;
-  }
+  // if (scanId && !uuidPattern.test(scanId.trim())) {
+  //   vscode.window.showErrorMessage(messages.scanIdIncorrectFormat);
+  //   return;
+  // }
   const scan = await getScanWithProgress(logs, scanId);
   if (!scan) {
     return;

--- a/src/utils/pickers/pickers.ts
+++ b/src/utils/pickers/pickers.ts
@@ -499,7 +499,7 @@ export async function loadScanId(
 ) {
 
   if (scanId && !uuidPattern.test(scanId.trim())) {
-    //vscode.window.showErrorMessage(messages.scanIdIncorrectFormat);
+    vscode.window.showErrorMessage(messages.scanIdIncorrectFormat);
     return;
   }
   const scan = await getScanWithProgress(logs, scanId);


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](../docs/code_of_conduct.md). Please see the [contributing guidelines](../docs/contributing.md) for how to create and submit a high-quality PR for this repo.

### Description

> Included the following checks during Scan search
- When an invalid scan ID is provided
- When the scan ID format is incorrect"

### References

> Include supporting link to GitHub Issue/PR number

### Testing
**Test Cases**
Case 1 - 
- Search with an invalid scan ID. 
Expected Output (Error Message) –    Failed Showing a scan:scan not found.

Case 2 - 
- Search with an invalid scan ID format. 
Expected Output – Invalid scan id format.

> Added unit tests and modification done in existing integration test

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR (if applicable).
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used