### PR TITLE
Sca hide dev & Test Dependency(AST-103537)

### DIFF
--- a/package.json
+++ b/package.json
@@ -407,6 +407,12 @@
         "enablement": "ast-results.isValidCredentials && view == astResults"
       },
       {
+        "command": "ast-results.filterSCAHideDevTestActive",
+        "category": "ast-results",
+        "title": "✓ Filter: SCA Hide Dev & Test Dependencies",
+        "enablement": "ast-results.isValidCredentials && view == astResults"
+      },
+      {
         "command": "ast-results.filterNotExploitable",
         "category": "ast-results",
         "title": "­­­ ­­ ­ ­ ­Filter: Not Exploitable",
@@ -455,6 +461,12 @@
         "enablement": "ast-results.isValidCredentials && view == astResults"
       },
       {
+        "command": "ast-results.filterSCAHideDevTest",
+        "category": "ast-results",
+        "title": "­­­ ­­ ­ ­ ­Filter: SCA Hide Dev & Test Dependencies",
+        "enablement": "ast-results.isValidCredentials && view == astResults"
+      },
+      {
         "command": "ast-results.filterNotExploitables",
         "category": "ast-results",
         "title": "Filter: Not Exploitable",
@@ -500,6 +512,12 @@
         "command": "ast-results.filterNotIgnoreds",
         "category": "ast-results",
         "title": "Filter: Not Ignored",
+        "enablement": "ast-results.isValidCredentials"
+      },
+      {
+        "command": "ast-results.filterSCAHideDevTests",
+        "category": "ast-results",
+        "title": "Filter: SCA Hide Dev & Test Dependencies",
         "enablement": "ast-results.isValidCredentials"
       },
       {
@@ -594,6 +612,16 @@
           "command": "ast-results.filterIgnored",
           "group": "navigation@2",
           "when": "!ast-results-Ignored"
+        },
+        {
+          "command": "ast-results.filterSCAHideDevTestActive",
+          "group": "navigation@8",
+          "when": "ast-results-SCAHideDevTest"
+        },
+        {
+          "command": "ast-results.filterSCAHideDevTest",
+          "group": "navigation@8",
+          "when": "!ast-results-SCAHideDevTest"
         }
       ],
       "view/item/context": [

--- a/src/commands/filterCommand.ts
+++ b/src/commands/filterCommand.ts
@@ -51,6 +51,7 @@ export class FilterCommand {
     this.registerFilterUrgentCommand();
     this.registerFilterNotIgnoredCommand();
     this.registerFilterIgnoredCommand();
+    this.registerFilterSCAHideDevTestCommand();
   }
 
   public async initializeFilters() {
@@ -111,6 +112,10 @@ export class FilterCommand {
     this.updateState(StateLevel.ignored, ignored);
     await updateStateFilter(this.context, constants.ignoredFilter, ignored);
     await vscode.commands.executeCommand(commands.refreshTree);
+
+    const scaHideDevTest =
+      this.context.globalState.get<boolean>(constants.scaHideDevTestFilter) ?? false;
+    await updateStateFilter(this.context, constants.scaHideDevTestFilter, scaHideDevTest);
   }
 
 
@@ -585,6 +590,42 @@ export class FilterCommand {
     );
   }
 
+  private registerFilterSCAHideDevTestCommand() {
+    this.context.subscriptions.push(
+      vscode.commands.registerCommand(
+        commands.filterSCAHideDevTest,
+        async () =>
+          await this.filterSCAHideDevTest(
+            this.logs,
+            this.context,
+            constants.scaHideDevTestFilter
+          )
+      )
+    );
+    this.context.subscriptions.push(
+      vscode.commands.registerCommand(
+        commands.filterSCAHideDevTestActive,
+        async () =>
+          await this.filterSCAHideDevTest(
+            this.logs,
+            this.context,
+            constants.scaHideDevTestFilter
+          )
+      )
+    );
+    this.context.subscriptions.push(
+      vscode.commands.registerCommand(
+        commands.filterSCAHideDevTestCommand,
+        async () =>
+          await this.filterSCAHideDevTest(
+            this.logs,
+            this.context,
+            constants.scaHideDevTestFilter
+          )
+      )
+    );
+  }
+
   private updateSeverities(
     activeSeverities: SeverityLevel,
     include: boolean
@@ -642,4 +683,16 @@ export class FilterCommand {
     await updateStateFilter(context, filter, !currentValue);
     await vscode.commands.executeCommand(commands.refreshTree);
   }
+
+  private async filterSCAHideDevTest(
+    logs: Logs,
+    context: vscode.ExtensionContext,
+    filter: string
+  ) {
+    logs.info(messages.filterResults("SCA Hide Dev/Test"));
+    const currentValue = context.globalState.get(filter);
+    await updateStateFilter(context, filter, !currentValue);
+    await vscode.commands.executeCommand(commands.refreshTree);
+  }
+
 }

--- a/src/unit/filterCommand.test.ts
+++ b/src/unit/filterCommand.test.ts
@@ -71,6 +71,7 @@ describe("FilterCommand", () => {
             expect(registeredCommands).to.include(commands.filterUrgent);
             expect(registeredCommands).to.include(commands.filterNotIgnored);
             expect(registeredCommands).to.include(commands.filterIgnored);
+            expect(registeredCommands).to.include(commands.filterSCAHideDevTest);
         });
     });
 }); 

--- a/src/utils/common/commands.ts
+++ b/src/utils/common/commands.ts
@@ -62,6 +62,10 @@ export const commands = {
   filterIgnoredActive: `${constants.extensionName}.filterIgnoredActive`,
   filterIgnoredCommand: `${constants.extensionName}.filterIgnoreds`,
 
+  filterSCAHideDevTest: `${constants.extensionName}.filterSCAHideDevTest`,
+  filterSCAHideDevTestActive: `${constants.extensionName}.filterSCAHideDevTestActive`,
+  filterSCAHideDevTestCommand: `${constants.extensionName}.filterSCAHideDevTests`,
+
   groupByFile: `${constants.extensionName}.groupByFile`,
   groupByFileActive: `${constants.extensionName}.groupByFileActive`,
   groupByFileCommand: `${constants.extensionName}.groupByFiles`,

--- a/src/utils/common/constants.ts
+++ b/src/utils/common/constants.ts
@@ -16,6 +16,7 @@ export const constants = {
   urgentFilter: "ast-results-Urgent",
   notIgnoredFilter: "ast-results-NotIgnored",
   ignoredFilter: "ast-results-Ignored",
+  scaHideDevTestFilter: "ast-results-SCAHideDevTest",
   queryNameGroup: "ast-results-groupByQueryName",
   languageGroup: "ast-results-groupByLanguage",
   severityGroup: "ast-results-groupBySeverity",

--- a/src/views/resultsProviders.ts
+++ b/src/views/resultsProviders.ts
@@ -21,7 +21,7 @@ export class ResultsProvider implements vscode.TreeDataProvider<TreeItem> {
   constructor(
     protected readonly context: vscode.ExtensionContext,
     protected readonly statusBarItem: vscode.StatusBarItem
-  ) {}
+  ) { }
 
   public getTreeItem(
     element: TreeItem
@@ -141,7 +141,7 @@ export class ResultsProvider implements vscode.TreeDataProvider<TreeItem> {
 
         // --- SCA Hide Dev & Test Dependencies filter logic ---
         // Check if obj is an SCA node (adjust this check as needed for your model)
-        const isScaNode = obj.type === "sca"; // <-- replace with your actual SCA type label
+        const isScaNode = obj.type === constants.sca; // <-- replace with your actual SCA type label
         const scaHideDevTest = this.context.globalState.get<boolean>(constants.scaHideDevTestFilter) ?? false;
 
         if (

--- a/src/views/resultsProviders.ts
+++ b/src/views/resultsProviders.ts
@@ -138,6 +138,24 @@ export class ResultsProvider implements vscode.TreeDataProvider<TreeItem> {
         (!obj.getState() || issueLevel.includes(obj.getSeverity())) &&
         (!obj.getState() || stateLevel.includes(obj.getState()))
       ) {
+
+        // --- SCA Hide Dev & Test Dependencies filter logic ---
+        // Check if obj is an SCA node (adjust this check as needed for your model)
+        const isScaNode = obj.type === "sca"; // <-- replace with your actual SCA type label
+        const scaHideDevTest = this.context.globalState.get<boolean>(constants.scaHideDevTestFilter) ?? false;
+
+        if (
+          isScaNode &&
+          scaHideDevTest &&
+          (
+            (obj.data?.scaPackageData.isDevelopmentDependency === true) ||
+            (obj.data?.scaPackageData.isTestDependency === true)
+          )
+        ) {
+          // Skip adding this item if it's a dev dependency and the filter is ON
+          return;
+        }
+
         if (obj.sastNodes.length > 0) {
           this.createDiagnostic(
             obj.label,
@@ -202,8 +220,8 @@ export class ResultsProvider implements vscode.TreeDataProvider<TreeItem> {
 
     const tree = previousValue.children
       ? previousValue.children.find(
-          (item) => item.label === value.replaceAll("_", " ")
-        )
+        (item) => item.label === value.replaceAll("_", " ")
+      )
       : undefined;
     if (tree) {
       tree.setDescription();


### PR DESCRIPTION
### Description
Feature Added:
Introduced a new filter option: "Filter : SCA Hide Dev & Test Dependencies".

Default Behavior:
The filter is disabled by default.

Functionality:
When enabled, this filter hides vulnerabilities associated with SCA Development and Test dependencies,


### Checklist

- [x] I have added documentation for new/changed functionality in this PR (if applicable).
- [x] The correct base branch is being used