### PR TITLE
Added a new hardcoded filter All Custom States(AST-99851)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,22 @@
 # CHANGELOG
 
-## [v2.34.1-IaC.0](https://github.com/Checkmarx/ast-vscode-extension/releases/tag/v2.34.1-IaC.0) - 2025-07-29 21:01:45
+## [v2.34.1-iac-realtime-5.8.0](https://github.com/Checkmarx/ast-vscode-extension/releases/tag/v2.34.1-iac-realtime-5.8.0) - 2025-08-03 10:50:37
 
 <!-- Release notes generated using configuration in .github/release.yml at main -->
 
 ## What's Changed
+### Checkmarx One SDK Updates 🛠
+* Update AST CLI JavaScript Wrapper to version 0.0.139 by @ast-phoenix in https://github.com/Checkmarx/ast-vscode-extension/pull/1232
 ### Other Changes
-* Add results priority (AST-105849) by @cx-sarah-chen in https://github.com/Checkmarx/ast-vscode-extension/pull/1227
-* Add Telemetry to Ignore Buttons (AST-107521) by @cx-sarah-chen in https://github.com/Checkmarx/ast-vscode-extension/pull/1228
+* Support ignoring secrets by value and apply ignore to all matches in same file (AST-107316) by @cx-itay-paz in https://github.com/Checkmarx/ast-vscode-extension/pull/1229
+* Add IaC Realtime Scanner (AST-102220) by @cx-sarah-chen in https://github.com/Checkmarx/ast-vscode-extension/pull/1231
 
 
-**Full Changelog**: https://github.com/Checkmarx/ast-vscode-extension/compare/v2.34.1-ignoeAndContainers.0...v2.34.1-IaC.0
+**Full Changelog**: https://github.com/Checkmarx/ast-vscode-extension/compare/v2.34.1-IaC.0...v2.34.1-iac-realtime-5.8.0
+
+## [v2.34.1-IaC.0](https://github.com/Checkmarx/ast-vscode-extension/releases/tag/v2.34.1-IaC.0) - 2025-07-29 21:01:45
+
+<!-- Release notes generated using configuration in .github/release.yml at main -->
 
 ## [v2.34.1-main-containers-ignore.0](https://github.com/Checkmarx/ast-vscode-extension/releases/tag/v2.34.1-main-containers-ignore.0) - 2025-07-27 15:00:54
 

--- a/package.json
+++ b/package.json
@@ -413,6 +413,12 @@
         "enablement": "ast-results.isValidCredentials && view == astResults"
       },
       {
+        "command": "ast-results.filterAllCustomStatesActive",
+        "category": "ast-results",
+        "title": "✓ Filter: All Custom States",
+        "enablement": "ast-results.isValidCredentials && view == astResults"
+      },
+      {
         "command": "ast-results.filterNotExploitable",
         "category": "ast-results",
         "title": "­­­ ­­ ­ ­ ­Filter: Not Exploitable",
@@ -464,6 +470,12 @@
         "command": "ast-results.filterSCAHideDevTest",
         "category": "ast-results",
         "title": "­­­ ­­ ­ ­ ­Filter: SCA Hide Dev & Test Dependencies",
+        "enablement": "ast-results.isValidCredentials && view == astResults"
+      },
+      {
+        "command": "ast-results.filterAllCustomStates",
+        "category": "ast-results",
+        "title": "­­­ ­­ ­ ­ ­Filter: All Custom States",
         "enablement": "ast-results.isValidCredentials && view == astResults"
       },
       {
@@ -521,6 +533,12 @@
         "enablement": "ast-results.isValidCredentials"
       },
       {
+        "command": "ast-results.filterAllCustomStatess",
+        "category": "ast-results",
+        "title": "Filter: All Custom States",
+        "enablement": "ast-results.isValidCredentials"
+      },
+      {
         "command": "ast-results.createSCAScan",
         "category": "ast-results",
         "title": "Run SCA Realtime Scan",
@@ -542,51 +560,11 @@
       }
     ],
     "menus": {
-      "ast-results.filterBy": [
-        {
-          "command": "ast-results.filterNotExploitableActive",
-          "group": "navigation@3",
-          "when": "ast-results-NotExploitable"
-        },
-        {
-          "command": "ast-results.filterProposedActive",
-          "group": "navigation@5",
-          "when": "ast-results-Proposed"
-        },
+      "ast-results.filterBy": [        
         {
           "command": "ast-results.filterConfirmedActive",
           "group": "navigation@1",
           "when": "ast-results-Confirmed"
-        },
-        {
-          "command": "ast-results.filterToVerifyActive",
-          "group": "navigation@6",
-          "when": "ast-results-ToVerify"
-        },
-        {
-          "command": "ast-results.filterUrgentActive",
-          "group": "navigation@7",
-          "when": "ast-results-Urgent"
-        },
-        {
-          "command": "ast-results.filterNotIgnoredActive",
-          "group": "navigation@4",
-          "when": "ast-results-NotIgnored"
-        },
-        {
-          "command": "ast-results.filterIgnoredActive",
-          "group": "navigation@2",
-          "when": "ast-results-Ignored"
-        },
-        {
-          "command": "ast-results.filterNotExploitable",
-          "group": "navigation@3",
-          "when": "!ast-results-NotExploitable"
-        },
-        {
-          "command": "ast-results.filterProposed",
-          "group": "navigation@5",
-          "when": "!ast-results-Proposed"
         },
         {
           "command": "ast-results.filterConfirmed",
@@ -594,19 +572,9 @@
           "when": "!ast-results-Confirmed"
         },
         {
-          "command": "ast-results.filterToVerify",
-          "group": "navigation@6",
-          "when": "!ast-results-ToVerify"
-        },
-        {
-          "command": "ast-results.filterUrgent",
-          "group": "navigation@7",
-          "when": "!ast-results-Urgent"
-        },
-        {
-          "command": "ast-results.filterNotIgnored",
-          "group": "navigation@4",
-          "when": "!ast-results-NotIgnored"
+          "command": "ast-results.filterIgnoredActive",
+          "group": "navigation@2",
+          "when": "ast-results-Ignored"
         },
         {
           "command": "ast-results.filterIgnored",
@@ -614,14 +582,74 @@
           "when": "!ast-results-Ignored"
         },
         {
+          "command": "ast-results.filterNotExploitableActive",
+          "group": "navigation@3",
+          "when": "ast-results-NotExploitable"
+        },
+        {
+          "command": "ast-results.filterNotExploitable",
+          "group": "navigation@3",
+          "when": "!ast-results-NotExploitable"
+        },
+        {
+          "command": "ast-results.filterNotIgnoredActive",
+          "group": "navigation@4",
+          "when": "ast-results-NotIgnored"
+        },
+        {
+          "command": "ast-results.filterNotIgnored",
+          "group": "navigation@4",
+          "when": "!ast-results-NotIgnored"
+        },
+        {
+          "command": "ast-results.filterProposedActive",
+          "group": "navigation@5",
+          "when": "ast-results-Proposed"
+        },
+        {
+          "command": "ast-results.filterProposed",
+          "group": "navigation@5",
+          "when": "!ast-results-Proposed"
+        },
+        {
           "command": "ast-results.filterSCAHideDevTestActive",
-          "group": "navigation@8",
+          "group": "navigation@6",
           "when": "ast-results-SCAHideDevTest"
         },
         {
           "command": "ast-results.filterSCAHideDevTest",
-          "group": "navigation@8",
+          "group": "navigation@6",
           "when": "!ast-results-SCAHideDevTest"
+        },
+        {
+          "command": "ast-results.filterToVerifyActive",
+          "group": "navigation@7",
+          "when": "ast-results-ToVerify"
+        },
+        {
+          "command": "ast-results.filterToVerify",
+          "group": "navigation@7",
+          "when": "!ast-results-ToVerify"
+        },
+        {
+          "command": "ast-results.filterUrgentActive",
+          "group": "navigation@8",
+          "when": "ast-results-Urgent"
+        },
+        {
+          "command": "ast-results.filterUrgent",
+          "group": "navigation@8",
+          "when": "!ast-results-Urgent"
+        },
+        {
+          "command": "ast-results.filterAllCustomStatesActive",
+          "group": "navigation@9",
+          "when": "ast-results-AllCustomStates"
+        },
+        {
+          "command": "ast-results.filterAllCustomStates",
+          "group": "navigation@9",
+          "when": "!ast-results-AllCustomStates"
         }
       ],
       "view/item/context": [

--- a/src/commands/filterCommand.ts
+++ b/src/commands/filterCommand.ts
@@ -52,6 +52,7 @@ export class FilterCommand {
     this.registerFilterNotIgnoredCommand();
     this.registerFilterIgnoredCommand();
     this.registerFilterSCAHideDevTestCommand();
+    this.registerFilterAllCustomStatesCommand();
   }
 
   public async initializeFilters() {
@@ -111,11 +112,17 @@ export class FilterCommand {
       this.context.globalState.get<boolean>(constants.ignoredFilter) ?? true;
     this.updateState(StateLevel.ignored, ignored);
     await updateStateFilter(this.context, constants.ignoredFilter, ignored);
-    await vscode.commands.executeCommand(commands.refreshTree);
 
     const scaHideDevTest =
       this.context.globalState.get<boolean>(constants.scaHideDevTestFilter) ?? false;
     await updateStateFilter(this.context, constants.scaHideDevTestFilter, scaHideDevTest);
+
+    const customStates =
+      this.context.globalState.get<boolean>(constants.allCustomStatesFilter) ?? true;
+    this.updateState(StateLevel.customStates, customStates);
+    await updateStateFilter(this.context, constants.allCustomStatesFilter, customStates);
+
+    await vscode.commands.executeCommand(commands.refreshTree);
   }
 
 
@@ -621,6 +628,44 @@ export class FilterCommand {
             this.logs,
             this.context,
             constants.scaHideDevTestFilter
+          )
+      )
+    );
+  }
+  private registerFilterAllCustomStatesCommand() {
+    this.context.subscriptions.push(
+      vscode.commands.registerCommand(
+        commands.filterAllCustomStates,
+        async () =>
+          await this.filterState(
+            this.logs,
+            this.context,
+            StateLevel.customStates,
+            constants.allCustomStatesFilter
+          )
+      )
+    );
+    this.context.subscriptions.push(
+      vscode.commands.registerCommand(
+        commands.filterAllCustomStatesActive,
+        async () =>
+          await this.filterState(
+            this.logs,
+            this.context,
+            StateLevel.customStates,
+            constants.allCustomStatesFilter
+          )
+      )
+    );
+    this.context.subscriptions.push(
+      vscode.commands.registerCommand(
+        commands.filterAllCustomStatesCommand,
+        async () =>
+          await this.filterState(
+            this.logs,
+            this.context,
+            StateLevel.customStates,
+            constants.allCustomStatesFilter
           )
       )
     );

--- a/src/models/results.ts
+++ b/src/models/results.ts
@@ -278,6 +278,8 @@ export class AstResult extends CxResult {
         return StateLevel.notIgnored;
       case "IGNORED":
         return StateLevel.ignored;
+      default:
+        return StateLevel.customStates;
     }
   }
 

--- a/src/unit/filterCommand.test.ts
+++ b/src/unit/filterCommand.test.ts
@@ -27,14 +27,14 @@ describe("FilterCommand", () => {
         } as any;
 
         const mockOutputChannel = {
-            append: () => {},
-            appendLine: () => {},
-            clear: () => {},
-            show: () => {},
-            hide: () => {},
-            dispose: () => {},
+            append: () => { },
+            appendLine: () => { },
+            clear: () => { },
+            show: () => { },
+            hide: () => { },
+            dispose: () => { },
             name: "Mock Output",
-            replace: () => {}
+            replace: () => { }
         } as vscode.OutputChannel;
 
         logs = new Logs(mockOutputChannel);
@@ -49,9 +49,9 @@ describe("FilterCommand", () => {
         sandbox.restore();
     });
 
-   
 
-   
+
+
     describe("registerFilters", () => {
         it("should register all filter commands", () => {
             const registerCommandStub = sandbox.stub(vscode.commands, "registerCommand");
@@ -72,6 +72,7 @@ describe("FilterCommand", () => {
             expect(registeredCommands).to.include(commands.filterNotIgnored);
             expect(registeredCommands).to.include(commands.filterIgnored);
             expect(registeredCommands).to.include(commands.filterSCAHideDevTest);
+            expect(registeredCommands).to.include(commands.filterAllCustomStates);
         });
     });
 }); 

--- a/src/utils/common/commands.ts
+++ b/src/utils/common/commands.ts
@@ -66,6 +66,10 @@ export const commands = {
   filterSCAHideDevTestActive: `${constants.extensionName}.filterSCAHideDevTestActive`,
   filterSCAHideDevTestCommand: `${constants.extensionName}.filterSCAHideDevTests`,
 
+  filterAllCustomStates: `${constants.extensionName}.filterAllCustomStates`,
+  filterAllCustomStatesActive: `${constants.extensionName}.filterAllCustomStatesActive`,
+  filterAllCustomStatesCommand: `${constants.extensionName}.filterAllCustomStatess`,
+
   groupByFile: `${constants.extensionName}.groupByFile`,
   groupByFileActive: `${constants.extensionName}.groupByFileActive`,
   groupByFileCommand: `${constants.extensionName}.groupByFiles`,

--- a/src/utils/common/constants.ts
+++ b/src/utils/common/constants.ts
@@ -17,6 +17,7 @@ export const constants = {
   notIgnoredFilter: "ast-results-NotIgnored",
   ignoredFilter: "ast-results-Ignored",
   scaHideDevTestFilter: "ast-results-SCAHideDevTest",
+  allCustomStatesFilter: "ast-results-AllCustomStates",
   queryNameGroup: "ast-results-groupByQueryName",
   languageGroup: "ast-results-groupByLanguage",
   severityGroup: "ast-results-groupBySeverity",
@@ -311,6 +312,7 @@ export enum StateLevel {
   notExploitable = "NotExploitable",
   notIgnored = "NotIgnored",
   ignored = "Ignored",
+  customStates = "CustomStates",
 }
 export enum QuickPickPaginationButtons {
   nextPage = "Next Page",


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](../docs/code_of_conduct.md). Please see the [contributing guidelines](../docs/contributing.md) for how to create and submit a high-quality PR for this repo.

### Description

This PR introduces a new filter option named "All Custom States" in the Checkmarx AST results panel of the VS Code extension. This filter allows users to view results that belong to any custom triage state returned by the backend via **cx.triageGetStates**.
The filtering logic has been updated to:

- Dynamically include results that match any of the custom states.
- Respect the toggle state of the "**All Custom States**" filter—when disabled, custom state results are excluded.
- Integrate seamlessly with existing severity and built-in state filters.

This enhancement improves flexibility for users managing custom triage workflows and aligns with extended backend capabilities.

### References

> Implements support for feature request in [AST-5496](https://checkmarx1.aha.io/features/AST-5496?reference-class=Feature)

### Testing

- Verified that the "All Custom States" filter appears in the filter list.
- Ensured the command toggles correctly and persists the selected state.
- Confirmed that only results with backend-defined custom states are shown when the filter is active.
- Checked that built-in state filtering behavior remains unchanged.
- Manually tested multiple scenarios with different combinations of filter states.
- Unit tested logic for filtering custom states in ResultsProvider.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR (if applicable).
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used

<img width="850" height="727" alt="image" src="https://github.com/user-attachments/assets/d39b8ebc-ba99-48d1-b6cb-5e92a46acc78" />



[AST-5496]: https://checkmarx.atlassian.net/browse/AST-5496?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ