### PR TITLE
Fix (AST-122003) and (AST-85900)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6387,9 +6387,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1088,6 +1088,9 @@
     },
     "vscode-extension-tester": {
       "glob": "11.1.0"
+    },
+    "codecov": {
+      "js-yaml": "3.14.2"
     }
   },
   "lint-staged": {


### PR DESCRIPTION

### Description

> Fix  (AST-122003) CVE-2025-64756 @ Npm-glob-11.0.3 and  (AST-85900) Cxdca8e59f-8bfe @ Npm-inflight-1.0.6 vulnerabilities

### References

> [AST-122003](https://checkmarx.atlassian.net/browse/AST-122003) 
> [AST-85900](https://checkmarx.atlassian.net/browse/AST-85900)

### Testing

> Describe how this change was tested. Be specific about anything not tested and reasons why. If this solution has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR (if applicable).
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used

[AST-122003]: https://checkmarx.atlassian.net/browse/AST-122003?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AST-85900]: https://checkmarx.atlassian.net/browse/AST-85900?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ