### PR TITLE
Add MCP unavailability disclosure and fallback remediation guidance (AST-145752)

### DIFF
--- a/packages/checkmarx/package-lock.json
+++ b/packages/checkmarx/package-lock.json
@@ -41,7 +41,7 @@
         "jsonstream-ts": "^1.3.6",
         "jwt-decode": "^4.0.0",
         "minimatch": "10.2.3",
-        "serialize-javascript": "^7.0.3",
+        "serialize-javascript": "^7.0.5",
         "tree-kill": "^1.2.2",
         "validator": "13.15.22"
       },

--- a/packages/checkmarx/package-lock.json
+++ b/packages/checkmarx/package-lock.json
@@ -5383,9 +5383,9 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.3.tgz",
-      "integrity": "sha512-h+cZ/XXarqDgCjo+YSyQU/ulDEESGGf8AMK9pPNmhNSl/FzPl6L8pMp1leca5z6NuG6tvV/auC8/43tmovowww==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {

--- a/packages/checkmarx/package-lock.json
+++ b/packages/checkmarx/package-lock.json
@@ -35,7 +35,7 @@
         "@checkmarx/ast-cli-javascript-wrapper": "0.0.155",
         "@popperjs/core": "^2.11.8",
         "@vscode/codicons": "^0.0.36",
-        "axios": "1.13.5",
+        "axios": "1.15.0",
         "dotenv": "^16.4.7",
         "https-proxy-agent": "^7.0.6",
         "jsonstream-ts": "^1.3.6",

--- a/packages/checkmarx/package.json
+++ b/packages/checkmarx/package.json
@@ -1153,7 +1153,7 @@
     "qs": "6.14.2",
     "underscore": "1.13.8",
     "mocha": {
-      "serialize-javascript": "7.0.3"
+      "serialize-javascript": "7.0.5"
     }
   }
 }

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -17,7 +17,7 @@
         "jsonstream-ts": "^1.3.6",
         "jwt-decode": "^4.0.0",
         "minimatch": "10.2.3",
-        "serialize-javascript": "^7.0.3",
+        "serialize-javascript": "^7.0.5",
         "tree-kill": "^1.2.2",
         "validator": "13.15.22"
       },
@@ -3574,9 +3574,9 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.3.tgz",
-      "integrity": "sha512-h+cZ/XXarqDgCjo+YSyQU/ulDEESGGf8AMK9pPNmhNSl/FzPl6L8pMp1leca5z6NuG6tvV/auC8/43tmovowww==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=20.0.0"

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -11,7 +11,7 @@
         "@checkmarx/ast-cli-javascript-wrapper": "0.0.155",
         "@popperjs/core": "^2.11.8",
         "@vscode/codicons": "^0.0.36",
-        "axios": "1.13.5",
+        "axios": "1.15.0",
         "dotenv": "^16.4.7",
         "https-proxy-agent": "^7.0.6",
         "jsonstream-ts": "^1.3.6",
@@ -1018,14 +1018,14 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -3382,10 +3382,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/randombytes": {
       "version": "2.1.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,7 +15,7 @@
     "@checkmarx/ast-cli-javascript-wrapper": "0.0.155",
     "@popperjs/core": "^2.11.8",
     "@vscode/codicons": "^0.0.36",
-    "axios": "1.13.5",
+    "axios": "1.15.0",
     "dotenv": "^16.4.7",
     "https-proxy-agent": "^7.0.6",
     "jsonstream-ts": "^1.3.6",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,7 +21,7 @@
     "jsonstream-ts": "^1.3.6",
     "jwt-decode": "^4.0.0",
     "minimatch": "10.2.3",
-    "serialize-javascript": "^7.0.3",
+    "serialize-javascript": "^7.0.5",
     "tree-kill": "^1.2.2",
     "validator": "13.15.22"
   },
@@ -48,7 +48,7 @@
     "@isaacs/brace-expansion": "5.0.1",
     "underscore": "1.13.8",
     "mocha": {
-      "serialize-javascript": "7.0.3"
+      "serialize-javascript": "7.0.5"
     }
   }
 }

--- a/packages/core/src/realtimeScanners/scanners/prompts.ts
+++ b/packages/core/src/realtimeScanners/scanners/prompts.ts
@@ -78,15 +78,14 @@ If any of these validations fail:
 
 4. OUTPUT:
 
-**Output Prefix Based on Tool Availability:**
-- **If packageRemediation tool WAS available:** Use \`${getAgentName()} -\` to indicate automated remediation was used (e.g., "Checkmarx One Assist -" or "Checkmarx Developer Assist -")
-- **If packageRemediation tool was NOT available:** Use \`AI-Generated Guidance -\` to clearly indicate manual guidance was provided (do NOT mention product name)
+**Output Format Based on Tool Availability:**
+- **If packageRemediation tool WAS available:** \`${getAgentName()} - Remediation Summary\`
+- **If packageRemediation tool was NOT available:** \`AI-Generated Remediation Guidance\`
 
 ✅ **Remediation Summary**
 
 Format:
 \`\`\`
-[Prefix] - Remediation Summary
 
 Package:     ${packageName}
 Version:     ${packageVersion}
@@ -221,14 +220,14 @@ If applicable for the language:
 
 6. OUTPUT FORMAT
 
-**Output Prefix Based on Tool Availability:**
-- **If codeRemediation tool WAS available:** Use \`${getAgentName()} -\` to indicate automated remediation was used
-- **If codeRemediation tool was NOT available:** Use \`AI-Generated Guidance -\` to clearly indicate manual guidance was provided (do NOT mention product name)
+**Output Format Based on Tool Availability:**
+- **If codeRemediation tool WAS available:** \`${getAgentName()} - Remediation Summary\` (e.g., "Checkmarx One Assist - Remediation Summary")
+- **If codeRemediation tool was NOT available:** \`AI-Generated Remediation Guidance\` (as the complete title, no additional suffix)
 
 Generate a structured remediation summary:
 
 \`\`\`markdown
-### [Prefix] - Secret Remediation Summary
+### [Prefix]
 
 **Secret:** ${title}  
 **Severity:** ${severity}  
@@ -546,15 +545,14 @@ Call the internal \`codeRemediation\` ${getProductName()} MCP tool with:
 
 4. OUTPUT:
 
-**Output Prefix Based on Tool Availability:**
-- **If codeRemediation tool WAS available:** Use \`${getAgentName()} -\` to indicate automated remediation was used
-- **If codeRemediation tool was NOT available:** Use \`AI-Generated Guidance -\` to clearly indicate manual guidance was provided (do NOT mention product name)
+**Output Format Based on Tool Availability:**
+- **If codeRemediation tool WAS available:** \`${getAgentName()} - Remediation Summary\` (e.g., "Checkmarx One Assist - Remediation Summary")
+- **If codeRemediation tool was NOT available:** \`AI-Generated Remediation Guidance\` (as the complete title, no additional suffix)
 
 ✅ **Remediation Summary**
 
 Format:
 \`\`\`
-[Prefix] - Remediation Summary
 
 Rule:        ${ruleName}
 Severity:    ${severity}
@@ -858,15 +856,14 @@ If any of these validations fail:
 
 4. OUTPUT:
 
-**Output Prefix Based on Tool Availability:**
-- **If imageRemediation tool WAS available:** Use \`${getAgentName()} -\` to indicate automated remediation was used
-- **If imageRemediation tool was NOT available:** Use \`AI-Generated Guidance -\` to clearly indicate manual guidance was provided (do NOT mention product name)
+**Output Format Based on Tool Availability:**
+- **If imageRemediation tool WAS available:** \`${getAgentName()} - Remediation Summary\` (e.g., "Checkmarx One Assist - Remediation Summary")
+- **If imageRemediation tool was NOT available:** \`AI-Generated Remediation Guidance\` (as the complete title, no additional suffix)
 
 ✅ **Remediation Summary**
 
 Format:
 \`\`\`
-[Prefix] - Remediation Summary
 
 File Type:    ${fileType}
 Image:        ${imageName}:${imageTag}
@@ -1007,15 +1004,14 @@ If any of these validations fail:
 
 4. OUTPUT:
 
-**Output Prefix Based on Tool Availability:**
-- **If codeRemediation tool WAS available:** Use \`${getAgentName()} -\` to indicate automated remediation was used
-- **If codeRemediation tool was NOT available:** Use \`AI-Generated Guidance -\` to clearly indicate manual guidance was provided (do NOT mention product name)
+**Output Format Based on Tool Availability:**
+- **If codeRemediation tool WAS available:** \`${getAgentName()} - Remediation Summary\` (e.g., "Checkmarx One Assist - Remediation Summary")
+- **If codeRemediation tool was NOT available:** \`AI-Generated Remediation Guidance\` (as the complete title, no additional suffix)
 
 ✅ **Remediation Summary**
 
 Format:
 \`\`\`
-[Prefix] - Remediation Summary
 
 Issue:       ${title}
 Severity:    ${severity}

--- a/packages/core/src/realtimeScanners/scanners/prompts.ts
+++ b/packages/core/src/realtimeScanners/scanners/prompts.ts
@@ -80,7 +80,7 @@ If any of these validations fail:
 
 **Output Prefix Based on Tool Availability:**
 - **If packageRemediation tool WAS available:** Use \`${getAgentName()} -\` to indicate automated remediation was used (e.g., "Checkmarx One Assist -" or "Checkmarx Developer Assist -")
-- **If packageRemediation tool was NOT available:** Use \`Security Assistant -\` to clearly indicate manual guidance was provided (do NOT mention product name)
+- **If packageRemediation tool was NOT available:** Use \`AI-Generated Guidance -\` to clearly indicate manual guidance was provided (do NOT mention product name)
 
 ✅ **Remediation Summary**
 
@@ -223,7 +223,7 @@ If applicable for the language:
 
 **Output Prefix Based on Tool Availability:**
 - **If codeRemediation tool WAS available:** Use \`${getAgentName()} -\` to indicate automated remediation was used
-- **If codeRemediation tool was NOT available:** Use \`Security Assistant -\` to clearly indicate manual guidance was provided (do NOT mention product name)
+- **If codeRemediation tool was NOT available:** Use \`AI-Generated Guidance -\` to clearly indicate manual guidance was provided (do NOT mention product name)
 
 Generate a structured remediation summary:
 
@@ -548,7 +548,7 @@ Call the internal \`codeRemediation\` ${getProductName()} MCP tool with:
 
 **Output Prefix Based on Tool Availability:**
 - **If codeRemediation tool WAS available:** Use \`${getAgentName()} -\` to indicate automated remediation was used
-- **If codeRemediation tool was NOT available:** Use \`Security Assistant -\` to clearly indicate manual guidance was provided (do NOT mention product name)
+- **If codeRemediation tool was NOT available:** Use \`AI-Generated Guidance -\` to clearly indicate manual guidance was provided (do NOT mention product name)
 
 ✅ **Remediation Summary**
 
@@ -860,7 +860,7 @@ If any of these validations fail:
 
 **Output Prefix Based on Tool Availability:**
 - **If imageRemediation tool WAS available:** Use \`${getAgentName()} -\` to indicate automated remediation was used
-- **If imageRemediation tool was NOT available:** Use \`Security Assistant -\` to clearly indicate manual guidance was provided (do NOT mention product name)
+- **If imageRemediation tool was NOT available:** Use \`AI-Generated Guidance -\` to clearly indicate manual guidance was provided (do NOT mention product name)
 
 ✅ **Remediation Summary**
 
@@ -1009,7 +1009,7 @@ If any of these validations fail:
 
 **Output Prefix Based on Tool Availability:**
 - **If codeRemediation tool WAS available:** Use \`${getAgentName()} -\` to indicate automated remediation was used
-- **If codeRemediation tool was NOT available:** Use \`Security Assistant -\` to clearly indicate manual guidance was provided (do NOT mention product name)
+- **If codeRemediation tool was NOT available:** Use \`AI-Generated Guidance -\` to clearly indicate manual guidance was provided (do NOT mention product name)
 
 ✅ **Remediation Summary**
 

--- a/packages/core/src/realtimeScanners/scanners/prompts.ts
+++ b/packages/core/src/realtimeScanners/scanners/prompts.ts
@@ -33,6 +33,12 @@ Call the internal PackageRemediation tool with:
 \`\`\`
 
 Parse the response and extract the \`fix_instructions\` field. This field contains the authoritative remediation steps tailored to the ecosystem and risk.
+- Mark internally that tool was **AVAILABLE** for output formatting
+
+- If the tool is **not available**:
+  - Display the following disclosure notice:
+  \`⚠️ Automated Remediation Unavailable: ${getProductName()} packageRemediation tool is unavailable. Proceeding with remediation guidance based on security best practices.\`
+  - Mark internally that tool was **NOT AVAILABLE** for output formatting
 
 ---
 
@@ -72,13 +78,15 @@ If any of these validations fail:
 
 4. OUTPUT:
 
-Prefix all output with: \`${getAgentName()} -\`
+**Output Prefix Based on Tool Availability:**
+- **If packageRemediation tool WAS available:** Use \`${getAgentName()} -\` to indicate automated remediation was used (e.g., "Checkmarx One Assist -" or "Checkmarx Developer Assist -")
+- **If packageRemediation tool was NOT available:** Use \`Security Assistant -\` to clearly indicate manual guidance was provided (do NOT mention product name)
 
 ✅ **Remediation Summary**
 
 Format:
 \`\`\`
-Security Assistant - Remediation Summary
+[Prefix] - Remediation Summary
 
 Package:     ${packageName}
 Version:     ${packageVersion}
@@ -173,9 +181,15 @@ Call the internal \`codeRemediation\` ${getProductName()} MCP tool with:
   - \`remediation_steps\` – exact steps to follow
   - \`best_practices\` – explain secure alternatives
   - \`description\` – contextual background
+  - Mark internally that tool was **AVAILABLE** for output formatting
 
-- If the tool is **not available**, display:
-  \`[MCP ERROR] codeRemediation tool is not available. Please check the ${getProductName()} MCP server.\`
+- If the tool is **not available**:
+  - Display the following disclosure notice:
+  \`⚠️ Automated Remediation Unavailable: ${getProductName()} codeRemediation tool is unavailable. Proceeding with remediation guidance based on security best practices.\`
+  - Mark internally that tool was **NOT AVAILABLE** for output formatting
+  - Proceed to provide remediation guidance using the secret details provided
+  - Offer practical steps and secure alternatives for secret removal
+  - Ensure the guidance is concrete and actionable
 
 ---
 
@@ -207,10 +221,14 @@ If applicable for the language:
 
 6. OUTPUT FORMAT
 
+**Output Prefix Based on Tool Availability:**
+- **If codeRemediation tool WAS available:** Use \`${getAgentName()} -\` to indicate automated remediation was used
+- **If codeRemediation tool was NOT available:** Use \`Security Assistant -\` to clearly indicate manual guidance was provided (do NOT mention product name)
+
 Generate a structured remediation summary:
 
 \`\`\`markdown
-### ${getAgentName()} - Secret Remediation Summary
+### [Prefix] - Secret Remediation Summary
 
 **Secret:** ${title}  
 **Severity:** ${severity}  
@@ -506,8 +524,12 @@ Call the internal \`codeRemediation\` ${getProductName()} MCP tool with:
 - If the tool is **available**, parse the response:
   - \`remediation_steps\` – exact steps to follow for remediation
 
-- If the tool is **not available**, display:
-  \`[MCP ERROR] codeRemediation tool is not available. Please check the ${getProductName()} MCP server.\`
+- If the tool is **not available**:
+  - Display the following disclosure notice:
+  \`⚠️ Automated Remediation Unavailable: ${getProductName()} codeRemediation tool is unavailable. Proceeding with remediation guidance based on security best practices.\`
+  - Proceed to provide remediation guidance using the issue details provided (rule name, description, severity, and recommended fix)
+  - Offer practical code examples and step-by-step instructions for manual remediation
+  - Ensure the guidance is concrete and actionable
 
 ---
 
@@ -524,13 +546,15 @@ Call the internal \`codeRemediation\` ${getProductName()} MCP tool with:
 
 4. OUTPUT:
 
-Prefix all output with: \`${getAgentName()} -\`
+**Output Prefix Based on Tool Availability:**
+- **If codeRemediation tool WAS available:** Use \`${getAgentName()} -\` to indicate automated remediation was used
+- **If codeRemediation tool was NOT available:** Use \`Security Assistant -\` to clearly indicate manual guidance was provided (do NOT mention product name)
 
 ✅ **Remediation Summary**
 
 Format:
 \`\`\`
-\`${getAgentName()} -\` - Remediation Summary
+[Prefix] - Remediation Summary
 
 Rule:        ${ruleName}
 Severity:    ${severity}
@@ -788,6 +812,15 @@ Call the internal imageRemediation tool with:
 \`\`\`
 
 Parse the response and extract the \`fix_instructions\` field. This field contains the authoritative remediation steps tailored to the container ecosystem and risk level.
+- Mark internally that tool was **AVAILABLE** for output formatting
+
+- If the tool is **not available**:
+  - Display the following disclosure notice:
+  \`⚠️ Automated Remediation Unavailable: ${getProductName()} imageRemediation tool is unavailable. Proceeding with remediation guidance based on security best practices.\`
+  - Mark internally that tool was **NOT AVAILABLE** for output formatting
+  - Proceed to provide remediation guidance using the container details provided (file type, image name, image tag, severity)
+  - Offer practical base image recommendations and step-by-step instructions for container remediation
+  - Ensure the guidance is concrete and actionable
 
 ---
 
@@ -825,13 +858,15 @@ If any of these validations fail:
 
 4. OUTPUT:
 
-Prefix all output with: \`${getAgentName()} -\`
+**Output Prefix Based on Tool Availability:**
+- **If imageRemediation tool WAS available:** Use \`${getAgentName()} -\` to indicate automated remediation was used
+- **If imageRemediation tool was NOT available:** Use \`Security Assistant -\` to clearly indicate manual guidance was provided (do NOT mention product name)
 
 ✅ **Remediation Summary**
 
 Format:
 \`\`\`
-Security Assistant - Remediation Summary
+[Prefix] - Remediation Summary
 
 File Type:    ${fileType}
 Image:        ${imageName}:${imageTag}
@@ -930,9 +965,15 @@ Call the internal \`codeRemediation\` ${getProductName()} MCP tool with:
 
 - If the tool is **available**, parse the response:
   - \`remediation_steps\` – exact steps to follow for remediation
+  - Mark internally that tool was **AVAILABLE** for output formatting
 
-- If the tool is **not available**, display:
-  \`[MCP ERROR] codeRemediation tool is not available. Please check the ${getProductName()} MCP server.\`
+- If the tool is **not available**:
+  - Display the following disclosure notice:
+  \`⚠️ Automated Remediation Unavailable: ${getProductName()} codeRemediation tool is unavailable. Proceeding with remediation guidance based on security best practices.\`
+  - Mark internally that tool was **NOT AVAILABLE** for output formatting
+  - Proceed to provide remediation guidance using the IaC details provided (title, description, expected vs. actual values)
+  - Offer practical configuration examples and step-by-step instructions for remediation
+  - Ensure the guidance is concrete and actionable
 
 ---
 
@@ -966,13 +1007,15 @@ If any of these validations fail:
 
 4. OUTPUT:
 
-Prefix all output with: \`${getAgentName()} -\`
+**Output Prefix Based on Tool Availability:**
+- **If codeRemediation tool WAS available:** Use \`${getAgentName()} -\` to indicate automated remediation was used
+- **If codeRemediation tool was NOT available:** Use \`Security Assistant -\` to clearly indicate manual guidance was provided (do NOT mention product name)
 
 ✅ **Remediation Summary**
 
 Format:
 \`\`\`
-Security Assistant - Remediation Summary
+[Prefix] - Remediation Summary
 
 Issue:       ${title}
 Severity:    ${severity}

--- a/packages/project-ignite/package-lock.json
+++ b/packages/project-ignite/package-lock.json
@@ -34,7 +34,7 @@
         "jsonstream-ts": "^1.3.6",
         "jwt-decode": "^4.0.0",
         "minimatch": "10.2.3",
-        "serialize-javascript": "^7.0.3",
+        "serialize-javascript": "^7.0.5",
         "tree-kill": "^1.2.2",
         "validator": "13.15.22"
       },

--- a/packages/project-ignite/package-lock.json
+++ b/packages/project-ignite/package-lock.json
@@ -28,7 +28,7 @@
         "@checkmarx/ast-cli-javascript-wrapper": "0.0.155",
         "@popperjs/core": "^2.11.8",
         "@vscode/codicons": "^0.0.36",
-        "axios": "1.13.5",
+        "axios": "1.15.0",
         "dotenv": "^16.4.7",
         "https-proxy-agent": "^7.0.6",
         "jsonstream-ts": "^1.3.6",


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Checkmarx Code of Conduct](../docs/code_of_conduct.md). Please see the [contributing guidelines](../docs/contributing.md) for how to create and submit a high-quality PR for this repo.

### Description

This PR adds graceful fallback handling for remediation prompts when Checkmarx MCP services (packageRemediation, codeRemediation, imageRemediation) are unavailable. Previously, users would see hard error messages and the LLM would stop providing remediation guidance. Now the system clearly discloses the unavailability and proceeds with manual remediation guidance.

## Changes

## Core Improvements
- **Disclosure Messages**: Added clear user-facing notifications when MCP tools are unavailable
- **Conditional Output Formatting**: Distinguished between automated (product name prefix) and manual guidance (generic "Security Assistant" prefix)
- **Manual Fallback Guidance**: For ASCA, SECRET, IAC, and CONTAINERS scanners, LLM now proceeds with manual remediation when tools unavailable
- **Consistent Messaging**: Unified disclosure format across all scanner types

## Updated Prompts
1. **SCA**: Added disclosure message + conditional output formatting
2. **SECRET**: Enhanced tool unavailability handling + conditional output formatting
3. **ASCA (SAST)**: Enhanced tool unavailability handling + conditional output formatting
4. **IAC**: Enhanced tool unavailability handling + conditional output formatting
5. **CONTAINERS**: Enhanced tool unavailability handling + conditional output formatting

## Files Modified
- `packages/core/src/realtimeScanners/scanners/prompts.ts` (VS Code Extension)

## Disclosure Message Format
⚠️ Automated Remediation Unavailable: [Service Name] service (MCP) is not accessible at the moment. Providing manual remediation guidance based on security best practices.

## Output Formatting
- **When MCP Tool IS Available**: `Checkmarx One Assist - Remediation Summary` (or Checkmarx Developer Assist)
- **When MCP Tool is NOT Available**: `Security Assistant - Remediation Summary`

## Benefits
✅ Users receive remediation guidance even when MCP tools are unavailable (parity with Container/OSS functionality)
✅ Clear, transparent communication about automation status
✅ Better user experience during service outages
✅ Consistent behavior across all scanner types (SCA, SECRET, ASCA, IAC, CONTAINERS)
✅ Applied to both VS Code and JetBrains plugins for consistency

## Fixes
- Resolves: AST-145752 - Case 00271508 | Bofa | Allow LLM to proceed when Checkmarx MCP service is not accessible.

### References

>[ AST-145752](https://checkmarx.atlassian.net/browse/AST-145752)

### Testing

- Tested all 5 scanner types with MCP tool unavailability scenarios
- Verified disclosure messages display correctly
- Confirmed conditional output formatting works as expected
- Tested on both **Checkmarx** and **Checkmarx Developer Assist** plugins

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR (if applicable).
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used