### PR TITLE
Fix: Results are not loaded on re-install plugin(AST-107449)

### DIFF
--- a/packages/core/src/utils/utils.ts
+++ b/packages/core/src/utils/utils.ts
@@ -203,10 +203,10 @@ export async function getResultsJson() {
 export function readResultsFromFile(
   resultJsonPath: string,
   scan: string
-): Promise<CxResult[]> {
+): Promise<CxResult[] | undefined> {
   return new Promise((resolve, reject) => {
     if (!fs.existsSync(resultJsonPath) || !scan) {
-      resolve([]);
+      resolve(undefined);
       return;
     }
 

--- a/packages/core/src/views/resultsView/astResultsProvider.ts
+++ b/packages/core/src/views/resultsView/astResultsProvider.ts
@@ -21,7 +21,7 @@ import { validateConfigurationAndLicense } from "../../utils/common/configValida
 
 export class AstResultsProvider extends ResultsProvider {
   public process;
-  public loadedResults: CxResult[];
+  public loadedResults: CxResult[] | undefined;
   private scan: Item | undefined;
   private riskManagementView: riskManagementView;
 
@@ -87,8 +87,8 @@ export class AstResultsProvider extends ResultsProvider {
       this.loadedResults = undefined;
       const scanIDItem = getFromState(this.context, constants.scanIdKey);
       let scanId = undefined;
-      if (scanIDItem && scanIDItem.name) {
-        scanId = getFromState(this.context, constants.scanIdKey).name;
+      if (scanIDItem && scanIDItem.id) {
+        scanId = getFromState(this.context, constants.scanIdKey).id;
       }
       if (scanId) {
         await getResultsWithProgress(this.logs, scanId);


### PR DESCRIPTION
## Summary
- Fixes issue where "Scan found no vulnerability" message was displayed prematurely while results were loading
- Changes `readResultsFromFile()` to return `undefined` when file doesn't exist (semantic distinction: undefined = not loaded, [] = loaded but empty)
- Updates `loadedResults` type annotation to `CxResult[] | undefined` to match actual usage
- Fixes scanId retrieval to use `.id` instead of `.name` for correct UUID

## Testing
- ✅ Results load correctly and display after file is created
- ✅ No premature "No vulnerability" message shown during loading
- ✅ Triage operations work without regression
- ✅ Filtering and grouping work correctly
- ✅ Risk management view handles undefined safely
- ✅ Both Checkmarx and Project Ignite plugins safe
- ✅ Zero regressions in existing functionality

## Type Safety
- Improves type safety by making optional nature of loadedResults explicit
- Pre-existing type inconsistency fixed (code was assigning undefined but type didn't allow it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)