### PR TITLE
fix(actions): declare secrets used by reusable workflows

### DIFF
--- a/.github/workflows/delete-dev-releases.yml
+++ b/.github/workflows/delete-dev-releases.yml
@@ -7,6 +7,9 @@ on:
         description: "Tag to delete"
         required: true
         type: string
+    secrets:
+      PERSONAL_ACCESS_TOKEN:
+        required: true
   workflow_dispatch:
     inputs:
       tag:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,15 @@ on:
         required: false
         type: string
         default: both
+    secrets:
+      GH_TOKEN:
+        required: true
+      MARKET_TOKEN:
+        required: true
+      OPEN_VSX_TOKEN:
+        required: true
+      PERSONAL_ACCESS_TOKEN:
+        required: true
   workflow_dispatch:
     inputs:
       releaseType:


### PR DESCRIPTION
Adds explicit on.workflow_call.secrets declarations for all secrets referenced in the workflow body, replacing implicit reliance on callers using secrets: inherit.