### PR TITLE
fix(AST-105262): close vulnerability description tab on logout

### DIFF
--- a/packages/checkmarx/src/views/checkmarxAuthViewProvider.ts
+++ b/packages/checkmarx/src/views/checkmarxAuthViewProvider.ts
@@ -22,14 +22,16 @@ export class CheckmarxAuthViewProvider implements vscode.WebviewViewProvider {
   private webviewView?: vscode.WebviewView;
   private readonly context: vscode.ExtensionContext;
   private readonly logs: Logs;
+  private readonly webViewCommand: WebViewCommand;
   private isAuthenticated: boolean = false;
   private isUpdating: boolean = false;
   private pendingUpdate: boolean = false;
   private isFirstLoad: boolean = true;
 
-  constructor(context: vscode.ExtensionContext, _webViewCommand: WebViewCommand, logs: Logs) {
+  constructor(context: vscode.ExtensionContext, webViewCommand: WebViewCommand, logs: Logs) {
     this.context = context;
     this.logs = logs;
+    this.webViewCommand = webViewCommand;
   }
 
   public resolveWebviewView(
@@ -429,6 +431,7 @@ export class CheckmarxAuthViewProvider implements vscode.WebviewViewProvider {
     if (selection === "Yes") {
       const authService = AuthService.getInstance(this.context, this.logs);
       await authService.logout();
+      this.webViewCommand.removedetailsPanel();
       vscode.window.showInformationMessage("Logged out successfully.");
       uninstallMcp();
       await vscode.commands.executeCommand(commands.refreshIgnoredStatusBar);


### PR DESCRIPTION
## Summary
- Stores `WebViewCommand` instance in `CheckmarxAuthViewProvider` (was previously discarded via `_` prefix)
- Calls `removedetailsPanel()` on logout to close the vulnerability description tab
- Prevents stale/outdated vulnerability details from remaining visible after the user logs out or switches environments

## Jira
[AST-105262](https://checkmarx.atlassian.net/browse/AST-105262) — Bug: VS Code | Vulnerability description tab remains open after logout and login to same or different environment

## Test plan
- [ ] Open a scan result and click a vulnerability to open the description tab
- [ ] Log out from the extension
- [ ] Verify the vulnerability description tab is closed automatically
- [ ] Log back in (same or different environment) and confirm no stale tab is present
- [ ] Verify logout flow still shows "Logged out successfully" message and clears the results tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AST-105262]: https://checkmarx.atlassian.net/browse/AST-105262?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ