### PR TITLE
AST-155307 Update CODEOWNERS default owners to cx-maintainers team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,4 +2,4 @@
 # Each line is a file pattern followed by one or more owners
 
 # Specify the default owners for the entire repository
-*       @AlvoBen @greensd4 @miryamfoiferCX
+*       @Checkmarx/cx-maintainers


### PR DESCRIPTION
Points the default CODEOWNERS entry at the @Checkmarx/cx-maintainers team instead of three named individuals, so repo-wide review assignment doesn't rot as people move teams. Follow-up to AST-155307. One-line change, no other diffs.
