### PR TITLE
AST-155307 Update CODEOWNERS default owners to cx-maintainers team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,4 +2,4 @@
 # Each line is a file pattern followed by one or more owners
 
 # Specify the default owners for the entire repository
-*       @AlvoBen @greensd4 @miryamfoiferCX
+*       @Checkmarx/cx-maintainers


### PR DESCRIPTION
Updates the repo-wide default CODEOWNERS entry from a fixed list of usernames to the @Checkmarx/cx-maintainers team, so review ownership tracks team membership instead of individual accounts. Single-line change to CODEOWNERS.
