### PR TITLE
Add support for additional SCA package managers (AST-164805)

### DIFF
--- a/packages/core/src/realtimeScanners/scanners/prompts.ts
+++ b/packages/core/src/realtimeScanners/scanners/prompts.ts
@@ -64,11 +64,20 @@ Examples:
 
 - If the instructions include build, test, or audit steps — run them exactly as written
 - If instructions do not explicitly cover validation, perform basic checks based on \`${packageManager}\`:
-  - \`npm\`: \`npx tsc --noEmit\`, \`npm run build\`, \`npm test\`
+  - \`npm\`: \`npx tsc --noEmit\`, \`npm run build\`, \`npm test\` (**IMPORTANT:** If you detect the file is \`bower.json\`, use \`bower install\`, \`bower list\` instead)
   - \`go\`: \`go build ./...\`, \`go test ./...\`
   - \`maven\`: \`mvn compile\`, \`mvn test\`
-  - \`pypi\`: \`python -c "import ${packageName}"\`, \`pytest\`
+  - \`gradle\`: \`gradle build\`, \`gradle test\`
+  - \`sbt\`: \`sbt compile\`, \`sbt test\`
+  - \`pypi\`/\`setuptools\`/\`pyproject.toml\`: \`python -c "import ${packageName}"\`, \`pytest\`, \`python -m build\`
   - \`nuget\`: \`dotnet build\`, \`dotnet test\`
+  - \`bower\` (\`bower.json\`): \`bower install\`, \`bower list\`
+  - \`rubygems\` (\`Gemfile\`): \`bundle install\`, \`bundle exec rspec\`
+  - \`packagist\` (\`composer.json\`): \`composer install\`, \`composer validate\`, \`vendor/bin/phpunit\` (**NOTE:** \`packagist\` means composer package manager)
+  - \`swift\` (\`Package.swift\`): \`swift build\`, \`swift test\`
+  - \`cocoapods\` (\`Podfile\`/\`Podfile.lock\`): \`pod install --repo-update\`, \`xcodebuild test\`
+  - \`carthage\` (\`Cartfile.resolved\`): \`carthage update --platform ios\`, \`carthage build\`
+  - \`pub\`/\`dart\` (\`pubspec.yaml\`/\`pubspec.lock\`): \`dart pub get\`, \`dart test\` (use \`flutter pub get\`, \`flutter test\` instead if this is a Flutter project)
 
 If any of these validations fail:
 - Attempt to fix the issue if it's obvious

--- a/packages/core/src/utils/common/constants.ts
+++ b/packages/core/src/utils/common/constants.ts
@@ -277,22 +277,47 @@ export const constants = {
   manualSetupAssistName: "manual",
 
   supportedManifestFilePatterns: [
+    // .NET
     "**/Directory.Packages.props",
     "**/packages.config",
-    "**/pom.xml",
-    "**/package.json",
-    "**/go.mod",
     "**/*.csproj",
-    "**/*.gradle",
-    "**/*.gradle.kts",
-    "**/*.sbt",
-    "**/libs.versions.toml",
+    // Maven
+    "**/pom.xml",
+    // npm
+    "**/package.json",
+    // Bower
+    "**/bower.json",
+    // Python
     "**/requirement*.txt",
     "**/constraints.txt",
     "**/constraints-*.txt",
     "**/pyproject.toml",
     "**/setup.cfg",
-    "**/setup.py"
+    "**/setup.py",
+    // Go
+    "**/go.mod",
+    // Gradle
+    "**/*.gradle",
+    "**/*.gradle.kts",
+    "**/libs.versions.toml",
+    // SBT
+    "**/*.sbt",
+    // iOS CocoaPods
+    "**/Podfile",
+    "**/*.podspec",
+    "**/*.podspec.json",
+    // iOS Carthage
+    "**/Cartfile",
+    "**/Cartfile.private",
+    // Swift Package Manager
+    "**/Package.swift",
+    "**/Package@swift-*.swift",
+    // Dart/Flutter
+    "**/pubspec.yaml",
+    // Ruby
+    "**/Gemfile",
+    // PHP Composer
+    "**/composer.json"
   ],
   ossIcons: {
     critical: "critical_severity.png",


### PR DESCRIPTION
## Summary
- Extend `supportedManifestFilePatterns` in [constants.ts](packages/core/src/utils/common/constants.ts) to detect manifests for Bower, iOS CocoaPods, iOS Carthage, Swift Package Manager, Dart/Flutter, RubyGems, and PHP Composer (in addition to existing .NET, Maven, npm, Python, Go, Gradle, and SBT support).
- Extend the SCA remediation verification step in [prompts.ts](packages/core/src/realtimeScanners/scanners/prompts.ts) with build/test commands for the newly supported package managers, plus previously-missing Gradle and SBT commands.

## Test plan
- [x] `npx tsc --noEmit` passes for `packages/core`
- [x] `npm run compile` succeeds for `packages/core`
- [x] `npm run unit-test-core` — all 1161 existing tests pass, no regressions
- [x] Manual diff review confirms only the manifest pattern list and remediation prompt were changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)