### PR TITLE
Exclude competitor references from View Details explanation output

### DIFF
--- a/packages/core/src/realtimeScanners/scanners/prompts.ts
+++ b/packages/core/src/realtimeScanners/scanners/prompts.ts
@@ -385,7 +385,7 @@ Conclude with:
 - Immediate remediation steps
 - Whether this specific version is linked to online reports
 - If not, reference ${getProductName()} attribution (per above rules)
-- Never mention competitor vendors or tools
+- Never mention checkmarx competitor(appsec vendors) or tools in the output. (MUST only include open-source advisory sources in the Sources section)
 
 ---
 
@@ -766,7 +766,7 @@ Conclude with:
 - Immediate remediation steps
 - Whether this specific image/tag is linked to online reports
 - If not, reference ${getProductName()} attribution (per above rules)
-- Never mention competitor vendors or tools
+- Never mention checkmarx competitor(appsec vendors) or tools in the output. (MUST only include open-source advisory sources in the Sources section)
 
 ---
 


### PR DESCRIPTION
The SCA and Containers explanation prompts instructed the model to search the web for "trusted community or vendor reports", then separately told it "Never mention competitor vendors or tools". When search results were dominated by security vendors, the model resolved the conflict in favour of citing them, and Snyk/Orca/Qualys links appeared in the Sources section.

 Updates the summary constraint in both prompts to say "appsec vendors" outright and to spell out that only open-source advisory sources belong in the Sources section, so the model no longer has to work out for itself who qualifies as a Checkmarx competitor.

