### PR TITLE
AST-171789 Fix release tag push failing without git credentials

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -446,10 +446,14 @@ jobs:
       # PUSH TAGS
       - name: Push tag
         if: inputs.dev == false
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git pull
-          git tag ${TAG_NAME}
-          git push --tags
+          SHA=$(gh api repos/${{ github.repository }}/commits/${{ github.ref_name }} --jq '.sha')
+          echo "Tagging ${TAG_NAME} at ${SHA}"
+          gh api repos/${{ github.repository }}/git/refs \
+            -f ref="refs/tags/${TAG_NAME}" \
+            -f sha="${SHA}"
 
       # CREATE UNIFIED GITHUB RELEASE (always 6 assets: 2 vsix + 2x source code auto-added by GitHub)
       - name: Create Unified Release


### PR DESCRIPTION
The Push tag step in release.yml runs `git push --tags`, but checkout uses `persist-credentials: false`, so there's no git auth available. This only surfaced on a real (dev=false) release, since that path had never run before.

Fix: create the tag via the GitHub API instead, resolving the branch's current head and creating the ref directly. This keeps persist-credentials disabled and preserves the original behavior of tagging after the version-bump PR merges.
