### PR TITLE
AST-171789 Fix Open VSX publish E401 by setting npm auth token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -533,6 +533,8 @@ jobs:
 
       # PUBLISH CHECKMARX TO OPEN VSX
       - name: Publish Checkmarx to Open VSX
+        env:
+          ECHO_LIBRARIES_ACCESS_KEY: ${{ secrets.ECHO_LIBRARIES_ACCESS_KEY }}
         if: |
           inputs.publish == true &&
           env.OPEN_VSX_TOKEN != '' &&
@@ -542,6 +544,8 @@ jobs:
 
       # PUBLISH CHECKMARX DEVELOPER ASSIST TO OPEN VSX
       - name: Publish Checkmarx Developer Assist to Open VSX
+        env:
+          ECHO_LIBRARIES_ACCESS_KEY: ${{ secrets.ECHO_LIBRARIES_ACCESS_KEY }}
         if: |
           inputs.publish == true &&
           env.OPEN_VSX_TOKEN != '' &&


### PR DESCRIPTION
Open VSX publish steps in release.yml failed with npm E401 on the first end-to-end release run. `npx ovsx` runs from the repo root and picks up the committed root `.npmrc`, whose auth line expands `ECHO_LIBRARIES_ACCESS_KEY` from the environment - but that variable was never set for these two steps, so the token resolved empty and the registry rejected the request.

Fix sets `ECHO_LIBRARIES_ACCESS_KEY` in the env of both Open VSX publish steps, matching the pattern already used by the npm auth step earlier in the job.
