### PR TITLE
AST-171789 Gate delete-dev-releases workflow behind release environment

### DIFF
--- a/.github/workflows/delete-dev-releases.yml
+++ b/.github/workflows/delete-dev-releases.yml
@@ -23,6 +23,7 @@ concurrency:
 jobs:
   delete:
     name: Delete Old Dev Releases
+    environment: release
     permissions:
       contents: write # For deleting releases and tags
     runs-on: cx-public-ubuntu-x64


### PR DESCRIPTION
The delete-dev-releases workflow permanently deletes GitHub releases and git tags, and anyone with repo write access can trigger it via workflow_dispatch with no gate at all.

This adds the `release` environment to the delete job, so the dispatch path now requires cx-maintainers approval and is restricted to the default branch, using the environment's existing reviewers and branch policy.

Note: release.yml calls this workflow pinned to an older SHA, so that path stays ungated until the pin is bumped.
