### PR TITLE
Add uv.lock companion resolution for pyproject.toml (AST-173775)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -448,10 +448,12 @@ jobs:
         if: inputs.dev == false
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPO: ${{ github.repository }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          SHA=$(gh api repos/${{ github.repository }}/commits/${{ github.ref_name }} --jq '.sha')
+          SHA=$(gh api repos/${GITHUB_REPO}/commits/${REF_NAME} --jq '.sha')
           echo "Tagging ${TAG_NAME} at ${SHA}"
-          gh api repos/${{ github.repository }}/git/refs \
+          gh api repos/${GITHUB_REPO}/git/refs \
             -f ref="refs/tags/${TAG_NAME}" \
             -f sha="${SHA}"
 

--- a/packages/core/src/realtimeScanners/scanners/oss/ossScannerService.ts
+++ b/packages/core/src/realtimeScanners/scanners/oss/ossScannerService.ts
@@ -324,9 +324,9 @@ export class OssScannerService extends BaseScannerService {
       return ["composer.lock"];
     }
 
-    // Python Poetry
+    // Python Poetry / uv
     if (fileName === "pyproject.toml") {
-      return ["poetry.lock"];
+      return ["poetry.lock", "uv.lock"];
     }
 
     // Dart/Flutter Pub


### PR DESCRIPTION
## Summary

Adds `uv.lock` to the companion-file map for `pyproject.toml`, so uv projects get exact pinned versions in OSS-realtime scans. Jira: **[AST-173001](https://checkmarx.atlassian.net/browse/AST-173001)**.

```ts
// Python Poetry / uv
if (fileName === "pyproject.toml") {
  return ["poetry.lock", "uv.lock"];   // was: ["poetry.lock"]
}
```

## Why this is needed

When a manifest is scanned, the extension copies it into a temp directory and copies only its **mapped companion lock files** alongside (`saveCompanionFile` → `getCompanionFileNames`). `pyproject.toml` is already scanned (Poetry), but only `poetry.lock` rode along — so for a **uv** project, the bundled CLI never received `uv.lock` and every ranged/unversioned dependency resolved to `"latest"`.

With this change, `uv.lock` is copied next to `pyproject.toml` into the temp scan dir, exactly like `poetry.lock`, and the CLI's parser resolves versions from it.

## Design note

`uv.lock` is treated as a **resolver-only sibling**, not a standalone scannable manifest — consistent with every other lock file here (`poetry.lock`, `package-lock.json`, `Podfile.lock`, …) and with the underlying manifest-parser design. `supportedManifestFilePatterns` is intentionally **not** changed; `pyproject.toml` remains the scanned file.

## Dependency

Relies on the bundled `cx` binary containing the manifest-parser uv support (manifest-parser [#27](https://github.com/Checkmarx/manifest-parser/pull/27) → ast-cli [#1551](https://github.com/Checkmarx/ast-cli/pull/1551)). The updated binary is already bundled on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[AST-173001]: https://checkmarx.atlassian.net/browse/AST-173001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ